### PR TITLE
feat(hal-api): Add error types for GPIO and I2C

### DIFF
--- a/crates/hal-api/error.rs
+++ b/crates/hal-api/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GpioError {
+    InvalidPin,
+    HardwareError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum I2cError {
+    InvalidAddress,
+    BusError,
+    Timeout,
+}
+

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod gpio;
 pub mod i2c;
 


### PR DESCRIPTION
# エラー型の設計と実装

## 概要

`hal-api`クレートにシンプルなエラー型を追加し、GPIOとI2Cのエラーハンドリングの基盤を整備しました。

## 変更内容

- `crates/hal-api/error.rs`を新規作成
  - `GpioError` enum: `InvalidPin`, `HardwareError`
  - `I2cError` enum: `InvalidAddress`, `BusError`, `Timeout`
- `crates/hal-api/lib.rs`に`pub mod error;`を追加

## 受け入れ基準

- [x] `hal-api/error.rs`が作成され、`lib.rs`でエクスポートされる
- [x] `GpioError`と`I2cError`が定義され、適切なderive属性が付与されている
- [x] 各traitの実装でエラー型が利用可能である

## テスト方法

```bash
cargo build -p hal-api
```

## 関連Issue

Closes #9

