### PR TITLE
feat(platform-pc-sim): Implement mock HAL for GPIO and I2C

### DIFF
--- a/crates/hal-api/error.rs
+++ b/crates/hal-api/error.rs
@@ -1,0 +1,13 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GpioError {
+    InvalidPin,
+    HardwareError,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum I2cError {
+    InvalidAddress,
+    BusError,
+    Timeout,
+}
+

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod gpio;
 pub mod i2c;
 

--- a/crates/platform-pc-sim/main.rs
+++ b/crates/platform-pc-sim/main.rs
@@ -1,4 +1,29 @@
+// 動作確認用の簡単なテストコード
+// このPRではモックHALのログ出力を確認するため、最小限の実装のみ
+mod mock_hal;
+use mock_hal::{MockPin, MockI2c};
+use hal_api::gpio::OutputPin;
+use hal_api::i2c::I2cBus;
+
 fn main() {
-    println!("pc sim");
+    println!("=== Mock HAL Test ===");
+    
+    // MockPinのテスト
+    let mut pin = MockPin::new(13);
+    println!("\nTesting MockPin:");
+    let _ = pin.set_high();
+    let _ = pin.set_low();
+    let _ = pin.set(true);
+    let _ = pin.set(false);
+    
+    // MockI2cのテスト
+    let mut i2c = MockI2c::new();
+    println!("\nTesting MockI2c:");
+    let _ = i2c.write(0x48, &[0x01, 0x02]);
+    let mut buffer = [0u8; 4];
+    let _ = i2c.read(0x48, &mut buffer);
+    let _ = i2c.write_read(0x48, &[0x03], &mut buffer);
+    
+    println!("\n=== Test Complete ===");
 }
 

--- a/crates/platform-pc-sim/mock_hal.rs
+++ b/crates/platform-pc-sim/mock_hal.rs
@@ -1,0 +1,67 @@
+use hal_api::error::{GpioError, I2cError};
+use hal_api::gpio::OutputPin;
+use hal_api::i2c::I2cBus;
+
+pub struct MockPin {
+    pin_number: u8,
+    state: bool,
+}
+
+impl MockPin {
+    pub fn new(pin_number: u8) -> Self {
+        Self {
+            pin_number,
+            state: false,
+        }
+    }
+}
+
+impl OutputPin for MockPin {
+    type Error = GpioError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.state = true;
+        println!("[GPIO] Pin {} set HIGH", self.pin_number);
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.state = false;
+        println!("[GPIO] Pin {} set LOW", self.pin_number);
+        Ok(())
+    }
+}
+
+pub struct MockI2c;
+
+impl MockI2c {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl I2cBus for MockI2c {
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        println!("[I2C] Write to 0x{:02X}: {:?}", addr, bytes);
+        Ok(())
+    }
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        println!("[I2C] Read from 0x{:02X}: {} bytes", addr, buffer.len());
+        buffer.fill(0xFF);
+        Ok(())
+    }
+
+    fn write_read(
+        &mut self,
+        addr: u8,
+        bytes: &[u8],
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        self.write(addr, bytes)?;
+        self.read(addr, buffer)
+    }
+}
+


### PR DESCRIPTION
# PCシミュレータのHAL実装（モック）

## 実装内容

`platform-pc-sim`クレートにモックHAL実装を追加しました。

### 追加ファイル
- `crates/platform-pc-sim/mock_hal.rs`: モックHAL実装

### 実装詳細

1. **MockPin構造体**
   - `pin_number: u8`と`state: bool`を持つ
   - `OutputPin` traitを実装
   - `set_high()`と`set_low()`で標準出力にログ出力

2. **MockI2c構造体**
   - `I2cBus` traitを実装
   - `write()`, `read()`, `write_read()`で標準出力にログ出力
   - `read()`はダミーデータ（0xFF）でバッファを埋める

### 依存関係

このPRはIssue #9（エラー型の実装）に依存しています。Issue #9のPR（#14）がマージされる必要があります。

## テスト方法

```bash
# ビルド確認
cargo build -p platform-pc-sim

# コンパイルエラーがないことを確認
```

## テスト結果

- ✅ `cargo build -p platform-pc-sim`が成功
- ✅ `MockPin`が`OutputPin` traitを正しく実装
- ✅ `MockI2c`が`I2cBus` traitを正しく実装
- ✅ コンパイルエラーなし

## 受け入れ基準

- [x] `platform-pc-sim/mock_hal.rs`が実装される
- [x] `MockPin`が`OutputPin`を実装する
- [x] `MockI2c`が`I2cBus`を実装する
- [x] GPIO/I2C操作が標準出力にログ出力される

## 関連Issue

Closes #10
Depends on #9 (PR #14)

