### PR TITLE
chore: add workspace resolver = "2" to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "crates/hal-api",
     "crates/core-app",


### PR DESCRIPTION
## Summary
- Cargo.tomlにworkspace resolver = "2"を追加してビルド警告を解消

## Details
ワークスペースのresolverバージョンを明示的に指定することで、cargo buildの警告を削除しました。resolver = "2"はRust Edition 2021のデフォルトで、依存関係の解決方法が改善されています。

## Test plan
- [x] `cargo build` が警告なしで成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)