### PR TITLE
test(platform-pc-sim): add comprehensive tests for mock HAL

### DIFF
--- a/crates/platform-pc-sim/mock_hal.rs
+++ b/crates/platform-pc-sim/mock_hal.rs
@@ -14,6 +14,18 @@ impl MockPin {
             state: false,
         }
     }
+
+    /// テスト用: ピン番号を取得
+    #[cfg(test)]
+    pub fn pin_number(&self) -> u8 {
+        self.pin_number
+    }
+
+    /// テスト用: 現在の状態を取得
+    #[cfg(test)]
+    pub fn state(&self) -> bool {
+        self.state
+    }
 }
 
 impl OutputPin for MockPin {
@@ -62,6 +74,193 @@ impl I2cBus for MockI2c {
     ) -> Result<(), Self::Error> {
         self.write(addr, bytes)?;
         self.read(addr, buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ===== MockPin Tests =====
+
+    #[test]
+    fn test_mock_pin_new() {
+        let pin = MockPin::new(13);
+        assert_eq!(pin.pin_number(), 13);
+        assert_eq!(pin.state(), false);
+    }
+
+    #[test]
+    fn test_mock_pin_new_different_pin_numbers() {
+        let pin1 = MockPin::new(5);
+        let pin2 = MockPin::new(42);
+        assert_eq!(pin1.pin_number(), 5);
+        assert_eq!(pin2.pin_number(), 42);
+    }
+
+    #[test]
+    fn test_mock_pin_set_high() {
+        let mut pin = MockPin::new(13);
+        assert!(pin.set_high().is_ok());
+        assert_eq!(pin.state(), true);
+    }
+
+    #[test]
+    fn test_mock_pin_set_low() {
+        let mut pin = MockPin::new(13);
+        pin.state = true; // 初期状態をHIGHに設定
+        assert!(pin.set_low().is_ok());
+        assert_eq!(pin.state(), false);
+    }
+
+    #[test]
+    fn test_mock_pin_set_with_true() {
+        let mut pin = MockPin::new(13);
+        assert!(pin.set(true).is_ok());
+        assert_eq!(pin.state(), true);
+    }
+
+    #[test]
+    fn test_mock_pin_set_with_false() {
+        let mut pin = MockPin::new(13);
+        pin.state = true;
+        assert!(pin.set(false).is_ok());
+        assert_eq!(pin.state(), false);
+    }
+
+    #[test]
+    fn test_mock_pin_toggle_sequence() {
+        let mut pin = MockPin::new(13);
+
+        pin.set_high().unwrap();
+        assert_eq!(pin.state(), true);
+
+        pin.set_low().unwrap();
+        assert_eq!(pin.state(), false);
+
+        pin.set_high().unwrap();
+        assert_eq!(pin.state(), true);
+    }
+
+    #[test]
+    fn test_mock_pin_multiple_set_high() {
+        let mut pin = MockPin::new(13);
+        pin.set_high().unwrap();
+        pin.set_high().unwrap();
+        pin.set_high().unwrap();
+        assert_eq!(pin.state(), true);
+    }
+
+    #[test]
+    fn test_mock_pin_implements_output_pin_trait() {
+        fn accepts_output_pin<T: OutputPin>(pin: &mut T) -> bool {
+            pin.set_high().is_ok()
+        }
+
+        let mut pin = MockPin::new(13);
+        assert!(accepts_output_pin(&mut pin));
+    }
+
+    // ===== MockI2c Tests =====
+
+    #[test]
+    fn test_mock_i2c_new() {
+        let _i2c = MockI2c::new();
+        // MockI2cは状態を持たないので、作成できることを確認
+    }
+
+    #[test]
+    fn test_mock_i2c_write() {
+        let mut i2c = MockI2c::new();
+        let data = [0x01, 0x02, 0x03];
+        assert!(i2c.write(0x48, &data).is_ok());
+    }
+
+    #[test]
+    fn test_mock_i2c_write_empty() {
+        let mut i2c = MockI2c::new();
+        assert!(i2c.write(0x48, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_mock_i2c_read() {
+        let mut i2c = MockI2c::new();
+        let mut buffer = [0u8; 4];
+        assert!(i2c.read(0x48, &mut buffer).is_ok());
+        assert_eq!(buffer, [0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_mock_i2c_read_fills_buffer_with_0xff() {
+        let mut i2c = MockI2c::new();
+        let mut buffer = [0x00, 0x11, 0x22, 0x33];
+        i2c.read(0x48, &mut buffer).unwrap();
+        assert_eq!(buffer, [0xFF, 0xFF, 0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_mock_i2c_read_different_sizes() {
+        let mut i2c = MockI2c::new();
+
+        let mut buffer1 = [0u8; 1];
+        i2c.read(0x48, &mut buffer1).unwrap();
+        assert_eq!(buffer1, [0xFF]);
+
+        let mut buffer8 = [0u8; 8];
+        i2c.read(0x48, &mut buffer8).unwrap();
+        assert_eq!(buffer8, [0xFF; 8]);
+    }
+
+    #[test]
+    fn test_mock_i2c_write_read() {
+        let mut i2c = MockI2c::new();
+        let write_data = [0x03];
+        let mut read_buffer = [0u8; 2];
+
+        assert!(i2c.write_read(0x48, &write_data, &mut read_buffer).is_ok());
+        assert_eq!(read_buffer, [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_mock_i2c_write_read_empty_write() {
+        let mut i2c = MockI2c::new();
+        let mut read_buffer = [0u8; 2];
+
+        assert!(i2c.write_read(0x48, &[], &mut read_buffer).is_ok());
+        assert_eq!(read_buffer, [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn test_mock_i2c_different_addresses() {
+        let mut i2c = MockI2c::new();
+        let mut buffer = [0u8; 2];
+
+        assert!(i2c.read(0x20, &mut buffer).is_ok());
+        assert!(i2c.read(0x48, &mut buffer).is_ok());
+        assert!(i2c.read(0x77, &mut buffer).is_ok());
+    }
+
+    #[test]
+    fn test_mock_i2c_implements_i2c_bus_trait() {
+        fn accepts_i2c_bus<T: I2cBus>(i2c: &mut T) -> bool {
+            let mut buffer = [0u8; 1];
+            i2c.read(0x48, &mut buffer).is_ok()
+        }
+
+        let mut i2c = MockI2c::new();
+        assert!(accepts_i2c_bus(&mut i2c));
+    }
+
+    #[test]
+    fn test_mock_i2c_multiple_operations() {
+        let mut i2c = MockI2c::new();
+
+        i2c.write(0x48, &[0x01]).unwrap();
+        let mut buffer = [0u8; 2];
+        i2c.read(0x48, &mut buffer).unwrap();
+        i2c.write_read(0x48, &[0x02], &mut buffer).unwrap();
+
+        assert_eq!(buffer, [0xFF, 0xFF]);
     }
 }
 


### PR DESCRIPTION
## Summary
- platform-pc-simのモックHAL実装に包括的なテストを追加
- 20個のユニットテスト（目標15個以上を達成）
- MockPinとMockI2cの全機能をカバー

## Details

### MockPin Tests（9個）

#### 初期化とピン設定（2個）
- `test_mock_pin_new`: デフォルト状態（LOW）で初期化
- `test_mock_pin_new_different_pin_numbers`: 異なるピン番号で初期化

#### 状態操作（4個）
- `test_mock_pin_set_high`: HIGH状態に設定
- `test_mock_pin_set_low`: LOW状態に設定
- `test_mock_pin_set_with_true`: set(true)でHIGH
- `test_mock_pin_set_with_false`: set(false)でLOW

#### シーケンステスト（2個）
- `test_mock_pin_toggle_sequence`: HIGH/LOWの切り替えシーケンス
- `test_mock_pin_multiple_set_high`: 連続したset_high()呼び出し

#### Trait実装（1個）
- `test_mock_pin_implements_output_pin_trait`: OutputPinトレイト実装確認

### MockI2c Tests（11個）

#### 初期化（1個）
- `test_mock_i2c_new`: MockI2c作成

#### Write操作（2個）
- `test_mock_i2c_write`: データ書き込み
- `test_mock_i2c_write_empty`: 空データ書き込み

#### Read操作（3個）
- `test_mock_i2c_read`: データ読み取り
- `test_mock_i2c_read_fills_buffer_with_0xff`: バッファが0xFFで埋まる
- `test_mock_i2c_read_different_sizes`: 異なるバッファサイズ

#### Write-Read操作（2個）
- `test_mock_i2c_write_read`: 書き込み後読み取り
- `test_mock_i2c_write_read_empty_write`: 空書き込み後読み取り

#### その他（3個）
- `test_mock_i2c_different_addresses`: 異なるI2Cアドレス
- `test_mock_i2c_implements_i2c_bus_trait`: I2cBusトレイト実装確認
- `test_mock_i2c_multiple_operations`: 複数操作の連続実行

### テストユーティリティ

#### MockPinヘルパーメソッド（#[cfg(test)]）
- `pin_number()`: ピン番号取得
- `state()`: 現在の状態取得

## Test plan
- [x] `cargo test -p platform-pc-sim` で20個のテストが全て通過
- [x] MockPinの全メソッドをテスト
- [x] MockI2cの全メソッドをテスト
- [x] トレイト実装の検証

## Test results
```
running 20 tests
test mock_hal::tests::test_mock_i2c_different_addresses ... ok
test mock_hal::tests::test_mock_i2c_implements_i2c_bus_trait ... ok
test mock_hal::tests::test_mock_i2c_new ... ok
test mock_hal::tests::test_mock_i2c_multiple_operations ... ok
test mock_hal::tests::test_mock_i2c_read ... ok
test mock_hal::tests::test_mock_i2c_read_fills_buffer_with_0xff ... ok
test mock_hal::tests::test_mock_i2c_read_different_sizes ... ok
test mock_hal::tests::test_mock_i2c_write ... ok
test mock_hal::tests::test_mock_i2c_write_empty ... ok
test mock_hal::tests::test_mock_i2c_write_read ... ok
test mock_hal::tests::test_mock_i2c_write_read_empty_write ... ok
test mock_hal::tests::test_mock_pin_implements_output_pin_trait ... ok
test mock_hal::tests::test_mock_pin_multiple_set_high ... ok
test mock_hal::tests::test_mock_pin_new ... ok
test mock_hal::tests::test_mock_pin_new_different_pin_numbers ... ok
test mock_hal::tests::test_mock_pin_set_high ... ok
test mock_hal::tests::test_mock_pin_set_low ... ok
test mock_hal::tests::test_mock_pin_set_with_false ... ok
test mock_hal::tests::test_mock_pin_set_with_true ... ok
test mock_hal::tests::test_mock_pin_toggle_sequence ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)