### PR TITLE
feat: add esp32c3 deploy scaffold

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.riscv32imc-unknown-none-elf]
+rustflags = [
+  "-C",
+  "link-arg=-Tlinkall.x",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Cargo.lock
 
 # Local temp/context files (Codex, IDE etc.)
 tmp/
+.tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/hal-api",
     "crates/core-app",
     "crates/platform-pc-sim",
+    "crates/platform-esp32",
 ]
 
 [package]
@@ -14,4 +15,3 @@ edition = "2021"
 [dependencies]
 hal-api = { path = "crates/hal-api" }
 core-app = { path = "crates/core-app" }
-

--- a/crates/core-app/Cargo.toml
+++ b/crates/core-app/Cargo.toml
@@ -3,9 +3,12 @@ name = "core-app"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["std"]
+std = ["hal-api/std"]
+
 [dependencies]
-hal-api = { path = "../hal-api" }
+hal-api = { path = "../hal-api", default-features = false }
 
 [lib]
 path = "lib.rs"
-

--- a/crates/core-app/lib.rs
+++ b/crates/core-app/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! # Core Application
 //!
 //! プラットフォーム非依存のアプリケーションロジック。
@@ -261,6 +263,7 @@ where
     ///     app.tick().unwrap();
     /// }
     /// ```
+    #[allow(unknown_lints)]
     #[allow(clippy::manual_is_multiple_of)]
     pub fn tick(&mut self) -> Result<(), AppError> {
         self.tick_count += 1;
@@ -456,7 +459,7 @@ mod tests {
     fn test_led_state_alternates() {
         let pin = MockPin::new();
         let i2c = MockI2c::new();
-        let mut app = App::new(pin.clone(), i2c);
+        let mut app = App::new(pin, i2c);
 
         // 100tick: HIGH
         for _ in 0..100 {

--- a/crates/hal-api/Cargo.toml
+++ b/crates/hal-api/Cargo.toml
@@ -3,6 +3,9 @@ name = "hal-api"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["std"]
+std = []
+
 [lib]
 path = "lib.rs"
-

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! # HAL API
 //!
 //! マイコン向けハードウェア抽象化層（HAL）のtrait定義。

--- a/crates/platform-esp32/Cargo.toml
+++ b/crates/platform-esp32/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "platform-esp32"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = ["std"]
+std = ["core-app/std", "hal-api/std"]
+esp32c3 = ["dep:esp-hal"]
+
+[dependencies]
+core-app = { path = "../core-app", default-features = false }
+hal-api = { path = "../hal-api", default-features = false }
+embedded-hal = "1.0.0"
+esp-hal = { version = "0.22.0", optional = true, default-features = false, features = ["esp32c3"] }
+
+[[bin]]
+name = "platform-esp32"
+path = "main.rs"

--- a/crates/platform-esp32/esp32_hal.rs
+++ b/crates/platform-esp32/esp32_hal.rs
@@ -1,0 +1,163 @@
+//! ESP32向けHALアダプタ
+//!
+//! `embedded-hal`実装を`hal-api` traitへ変換するための薄いアダプタ層です。
+
+use embedded_hal::digital::OutputPin as EmbeddedOutputPin;
+use embedded_hal::i2c::I2c as EmbeddedI2c;
+use hal_api::error::{GpioError, I2cError};
+use hal_api::gpio::OutputPin;
+use hal_api::i2c::I2cBus;
+
+/// `embedded-hal`のOutputPinを`hal-api::OutputPin`へ適合させるアダプタ。
+pub struct Esp32OutputPin<PIN> {
+    pin: PIN,
+}
+
+impl<PIN> Esp32OutputPin<PIN> {
+    #[cfg(any(test, feature = "esp32c3"))]
+    pub fn new(pin: PIN) -> Self {
+        Self { pin }
+    }
+}
+
+impl<PIN> OutputPin for Esp32OutputPin<PIN>
+where
+    PIN: EmbeddedOutputPin,
+{
+    type Error = GpioError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.pin.set_high().map_err(|_| GpioError::HardwareError)
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.pin.set_low().map_err(|_| GpioError::HardwareError)
+    }
+}
+
+/// `embedded-hal`のI2Cを`hal-api::I2cBus`へ適合させるアダプタ。
+pub struct Esp32I2c<I2C> {
+    i2c: I2C,
+}
+
+impl<I2C> Esp32I2c<I2C> {
+    #[cfg(any(test, feature = "esp32c3"))]
+    pub fn new(i2c: I2C) -> Self {
+        Self { i2c }
+    }
+
+    fn validate_addr(addr: u8) -> Result<(), I2cError> {
+        if addr <= 0x7F {
+            Ok(())
+        } else {
+            Err(I2cError::InvalidAddress)
+        }
+    }
+}
+
+impl<I2C> I2cBus for Esp32I2c<I2C>
+where
+    I2C: EmbeddedI2c,
+{
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        Self::validate_addr(addr)?;
+        self.i2c.write(addr, bytes).map_err(|_| I2cError::BusError)
+    }
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        Self::validate_addr(addr)?;
+        self.i2c.read(addr, buffer).map_err(|_| I2cError::BusError)
+    }
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        Self::validate_addr(addr)?;
+        self.i2c
+            .write_read(addr, bytes, buffer)
+            .map_err(|_| I2cError::BusError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::convert::Infallible;
+    use embedded_hal::digital::ErrorType as DigitalErrorType;
+    use embedded_hal::i2c::ErrorType as I2cErrorType;
+    use embedded_hal::i2c::Operation;
+
+    #[derive(Default)]
+    struct TestPin {
+        is_high: bool,
+    }
+
+    impl DigitalErrorType for TestPin {
+        type Error = Infallible;
+    }
+
+    impl EmbeddedOutputPin for TestPin {
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            self.is_high = false;
+            Ok(())
+        }
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            self.is_high = true;
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct TestI2c {
+        read_count: usize,
+    }
+
+    impl I2cErrorType for TestI2c {
+        type Error = Infallible;
+    }
+
+    impl EmbeddedI2c for TestI2c {
+        fn transaction(
+            &mut self,
+            _address: u8,
+            operations: &mut [Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            for op in operations {
+                if let Operation::Read(buf) = op {
+                    self.read_count += 1;
+                    buf.fill(0xAB);
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_esp32_output_pin_adapter() {
+        let pin = TestPin::default();
+        let mut adapter = Esp32OutputPin::new(pin);
+        assert!(adapter.set_high().is_ok());
+        assert!(adapter.set_low().is_ok());
+    }
+
+    #[test]
+    fn test_esp32_i2c_adapter_read() {
+        let i2c = TestI2c::default();
+        let mut adapter = Esp32I2c::new(i2c);
+
+        let mut buf = [0_u8; 4];
+        assert!(adapter.read(0x48, &mut buf).is_ok());
+        assert_eq!(buf, [0xAB; 4]);
+    }
+
+    #[test]
+    fn test_esp32_i2c_adapter_rejects_invalid_address() {
+        let i2c = TestI2c::default();
+        let mut adapter = Esp32I2c::new(i2c);
+        let mut buf = [0_u8; 2];
+
+        let err = adapter.read(0x80, &mut buf).unwrap_err();
+        assert_eq!(err, I2cError::InvalidAddress);
+    }
+}

--- a/crates/platform-esp32/main.rs
+++ b/crates/platform-esp32/main.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(all(feature = "esp32c3", not(feature = "std")), no_std)]
+#![cfg_attr(all(feature = "esp32c3", not(feature = "std")), no_main)]
+
+#[cfg(all(feature = "esp32c3", not(feature = "std")))]
+mod embedded_main {
+    use core_app::App;
+    use esp_hal::clock::CpuClock;
+    use esp_hal::delay::Delay;
+    use esp_hal::gpio::{Level, Output};
+    use esp_hal::i2c::master::{Config as I2cConfig, I2c};
+    use esp_hal::{entry, Config};
+
+    use crate::esp32_hal::{Esp32I2c, Esp32OutputPin};
+
+    #[panic_handler]
+    fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+        loop {}
+    }
+
+    #[entry]
+    fn main() -> ! {
+        let peripherals = esp_hal::init({
+            let mut config = Config::default();
+            config.cpu_clock = CpuClock::max();
+            config
+        });
+
+        let led = Output::new(peripherals.GPIO8, Level::Low);
+
+        let i2c = I2c::new(peripherals.I2C0, I2cConfig::default())
+            .with_sda(peripherals.GPIO4)
+            .with_scl(peripherals.GPIO5);
+
+        let mut app = App::new(Esp32OutputPin::new(led), Esp32I2c::new(i2c));
+        let delay = Delay::new();
+
+        loop {
+            let _ = app.tick();
+            delay.delay_millis(10);
+        }
+    }
+}
+
+#[cfg(not(all(feature = "esp32c3", not(feature = "std"))))]
+fn main() {
+    println!("platform-esp32 host mode");
+    println!("Use one of the following commands for device deployment:");
+    println!("  cargo run -p platform-esp32 --no-default-features --features esp32c3 --target riscv32imc-unknown-none-elf");
+    println!("  ./scripts/dev-loop.sh flash");
+}
+
+mod esp32_hal;

--- a/scripts/dev-loop.sh
+++ b/scripts/dev-loop.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Development loop helper:
+# - sim:   run PC simulator
+# - flash: build + flash + monitor for ESP32-C3
+# - check: run host tests + ESP32 build check
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+TARGET_TRIPLE="${TARGET_TRIPLE:-riscv32imc-unknown-none-elf}"
+BOARD_FEATURE="${BOARD_FEATURE:-esp32c3}"
+PACKAGE_NAME="platform-esp32"
+BIN_NAME="platform-esp32"
+MIN_RUST_VERSION="1.82.0"
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} <sim|flash|check> [serial_port]
+
+Commands:
+  sim                 Run PC simulator (platform-pc-sim)
+  flash [serial_port] Build + flash + monitor on ESP32-C3
+  check               Run host tests and ESP32 cross-build check
+
+Environment overrides:
+  TARGET_TRIPLE       Default: ${TARGET_TRIPLE}
+  BOARD_FEATURE       Default: ${BOARD_FEATURE}
+EOF
+}
+
+ensure_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: command not found: $1" >&2
+    exit 1
+  fi
+}
+
+ensure_rust_target() {
+  ensure_command rustup
+  if ! rustup target list --installed | grep -qx "${TARGET_TRIPLE}"; then
+    echo "Error: rust target '${TARGET_TRIPLE}' is not installed." >&2
+    echo "Install with: rustup target add ${TARGET_TRIPLE}" >&2
+    exit 1
+  fi
+}
+
+version_ge() {
+  local found="${1}"
+  local required="${2}"
+  local f_major f_minor f_patch r_major r_minor r_patch
+
+  IFS='.' read -r f_major f_minor f_patch <<<"${found}"
+  IFS='.' read -r r_major r_minor r_patch <<<"${required}"
+  f_patch="${f_patch:-0}"
+  r_patch="${r_patch:-0}"
+
+  if (( f_major > r_major )); then
+    return 0
+  fi
+  if (( f_major < r_major )); then
+    return 1
+  fi
+  if (( f_minor > r_minor )); then
+    return 0
+  fi
+  if (( f_minor < r_minor )); then
+    return 1
+  fi
+  (( f_patch >= r_patch ))
+}
+
+ensure_rust_version() {
+  ensure_command rustc
+  local current
+  current="$(rustc --version | awk '{print $2}')"
+
+  if ! version_ge "${current}" "${MIN_RUST_VERSION}"; then
+    echo "Error: rustc ${MIN_RUST_VERSION}+ is required for ESP32 build path." >&2
+    echo "Current rustc: ${current}" >&2
+    echo "Update with: rustup update stable" >&2
+    exit 1
+  fi
+}
+
+run_sim() {
+  cargo run -p platform-pc-sim
+}
+
+run_flash() {
+  local serial_port="${1:-}"
+  local artifact="target/${TARGET_TRIPLE}/release/${BIN_NAME}"
+  local flash_args=(flash --monitor --chip "${BOARD_FEATURE}")
+
+  ensure_command cargo
+  ensure_command espflash
+  ensure_rust_version
+  ensure_rust_target
+
+  cargo build \
+    -p "${PACKAGE_NAME}" \
+    --release \
+    --target "${TARGET_TRIPLE}" \
+    --no-default-features \
+    --features "${BOARD_FEATURE}"
+
+  if [[ ! -f "${artifact}" ]]; then
+    echo "Error: built artifact not found: ${artifact}" >&2
+    exit 1
+  fi
+
+  if [[ -n "${serial_port}" ]]; then
+    flash_args+=(--port "${serial_port}")
+  fi
+  flash_args+=("${artifact}")
+
+  espflash "${flash_args[@]}"
+}
+
+run_check() {
+  ensure_command cargo
+  ensure_rust_version
+  ensure_rust_target
+
+  cargo test --all
+  cargo build \
+    -p "${PACKAGE_NAME}" \
+    --release \
+    --target "${TARGET_TRIPLE}" \
+    --no-default-features \
+    --features "${BOARD_FEATURE}"
+}
+
+main() {
+  local command="${1:-}"
+  case "${command}" in
+    sim)
+      run_sim
+      ;;
+    flash)
+      run_flash "${2:-}"
+      ;;
+    check)
+      run_check
+      ;;
+    -h|--help|"")
+      usage
+      ;;
+    *)
+      echo "Error: unknown command '${command}'" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
Issue #39 の実装本体として、シミュレータ実装をESP32-C3実機へ繋ぐ最小構成を追加します。

## 変更内容
- `hal-api` / `core-app` に `no_std` 対応用 feature を追加
- `crates/platform-esp32` を追加
  - `Esp32OutputPin` / `Esp32I2c` の `hal-api` アダプタ
  - ESP32-C3 用 `main`（10ms tick）
- `.cargo/config.toml` に `riscv32imc-unknown-none-elf` のリンク設定を追加（`linkall.x`）
- `scripts/dev-loop.sh` を追加（`sim` / `flash` / `check`）
- ワークスペースへ `platform-esp32` を追加
- `.gitignore` に `.tmp/` を追加

## 影響範囲
- 実装コード:
  - `crates/hal-api`
  - `crates/core-app`
  - `crates/platform-esp32`（新規）
- 開発ツール:
  - `.cargo/config.toml`（新規）
  - `scripts/dev-loop.sh`（新規）

## テスト証跡
- `cargo test --all --quiet` : 成功
- `cargo clippy --all --all-targets -- -D warnings` : 成功
- `RUSTUP_TOOLCHAIN=1.82.0 ./scripts/dev-loop.sh check` : 成功
- `cargo +1.82.0 build -p platform-esp32 --release --target riscv32imc-unknown-none-elf --no-default-features --features esp32c3` : 成功

## ロールバック手順
- 本PRを `Revert` することで、ESP32-C3 実機連携導線（`platform-esp32` / `dev-loop.sh` / `no_std` feature 追加）を一括で戻せます。

## 関連Issue
- Closes #39
