### PR TITLE
ci: add esp32c3 build job and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,40 @@ jobs:
       - name: Build release
         run: cargo build --all --release --verbose
 
+  build-esp32c3:
+    name: Build ESP32-C3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add ESP32-C3 target
+        run: rustup target add riscv32imc-unknown-none-elf
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Build platform-esp32 for ESP32-C3
+        run: cargo build -p platform-esp32 --release --target riscv32imc-unknown-none-elf --no-default-features --features esp32c3 --verbose
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - **🎯 プラットフォーム非依存**: HAL traitを使用し、同じアプリケーションコードを複数のプラットフォームで実行
 - **💻 PCシミュレータ**: 実機なしで開発・デバッグが可能
+- **⚡ 高速デプロイループ**: `./scripts/dev-loop.sh flash` でESP32-C3へビルド+書き込み+モニタ
 - **🧪 テスト駆動開発**: 57個のテストでコードの品質を保証
 - **🔧 CI/CD自動化**: GitHub Actionsで自動ビルド・テスト・Lint
 - **🚀 将来の拡張性**: ESP32、Arduino Nano、Raspberry Pi Picoなどへの対応を予定
@@ -35,7 +36,7 @@
         ┌────────┴────────┐
         │                 │
 ┌───────▼──────┐  ┌──────▼────────┐
-│ PC Simulator │  │ ESP32 (予定)  │
+│ PC Simulator │  │ ESP32-C3      │
 │ platform-    │  │ platform-     │
 │ pc-sim       │  │ esp32         │
 │ - MockPin    │  │ - Esp32Pin    │
@@ -48,6 +49,7 @@
 ### 前提条件
 
 - Rust 1.70以降（[rustup](https://rustup.rs/)でインストール）
+- ESP32-C3実機デプロイを使う場合は Rust 1.82 以降を推奨
 
 ### ビルド
 
@@ -68,6 +70,9 @@ cargo build --release
 ```bash
 # PCシミュレータを実行
 cargo run -p platform-pc-sim
+
+# ESP32-C3へビルド + 書き込み + モニタ（要 espflash）
+./scripts/dev-loop.sh flash
 ```
 
 **期待される出力:**
@@ -80,6 +85,14 @@ cargo run -p platform-pc-sim
 ```
 
 Ctrl+Cで終了します。
+
+ESP32-C3向けの事前準備:
+
+```bash
+# 1回だけ実行
+cargo install espflash
+rustup target add riscv32imc-unknown-none-elf
+```
 
 ### テスト
 
@@ -140,6 +153,10 @@ mcu-hal-sim-rs/
 │       ├── main.rs       # エントリポイント（10ms tickループ）
 │       └── mock_hal.rs   # モックHAL実装
 │
+│   └── platform-esp32/   # ESP32-C3実機向け実装
+│       ├── main.rs       # 実機エントリポイント（10ms tickループ）
+│       └── esp32_hal.rs  # embedded-hal -> hal-api アダプタ
+│
 ├── .github/
 │   └── workflows/
 │       └── ci.yml        # CI/CD設定
@@ -156,6 +173,7 @@ mcu-hal-sim-rs/
 | **hal-api** | HAL trait定義（`OutputPin`, `I2cBus`など） | なし |
 | **core-app** | プラットフォーム非依存のアプリケーションロジック | `hal-api` |
 | **platform-pc-sim** | PCシミュレータ実装（モックHAL） | `hal-api`, `core-app` |
+| **platform-esp32** | ESP32-C3実機向け実装（GPIO/I2Cアダプタ） | `hal-api`, `core-app`, `embedded-hal`, `esp-hal` |
 
 ## 🧪 テスト
 
@@ -204,8 +222,8 @@ mcu-hal-sim-rs/
 - [x] **Week 3**: CI/CD環境の構築
 - [x] **Week 4**: ドキュメント充実
 - [ ] **Week 5**: 統合テスト・カバレッジ向上（次のフェーズ）
-- [ ] **Week 6**: no_std対応・ESP32準備
-- [ ] **Week 7-8**: ESP32実機対応（オプション）
+- [x] **Week 6**: no_std対応・ESP32準備
+- [x] **Week 7-8**: ESP32-C3実機デプロイ導線の追加
 
 詳細は [CHANGELOG.md](./CHANGELOG.md) と [開発計画](https://github.com/1222-takeshi/mcu-hal-sim-rs/blob/main/.claude/plans/hazy-drifting-frost.md) を参照してください。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -164,3 +164,36 @@ fi
 # デフォルトのワークフロー名を変更
 RUN_ID=$(gh run list --workflow=custom-workflow.yml --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
+
+---
+
+### `dev-loop.sh` - シミュレータ/実機高速ループ
+
+シミュレータで確認したコードを、ESP32-C3へ素早く反映するためのスクリプトです。
+
+**使用方法:**
+
+```bash
+# PCシミュレータを実行
+./scripts/dev-loop.sh sim
+
+# 実機へビルド + 書き込み + モニタ
+./scripts/dev-loop.sh flash
+
+# ポートを明示する場合
+./scripts/dev-loop.sh flash /dev/tty.usbserial-0001
+
+# ホストテスト + ESP32クロスビルド確認
+./scripts/dev-loop.sh check
+```
+
+**前提条件:**
+
+- `espflash` がインストールされていること
+- `riscv32imc-unknown-none-elf` ターゲットがインストールされていること
+- `rustc` が 1.82 以上であること（`esp-hal` と依存クレートの要件）
+
+```bash
+cargo install espflash
+rustup target add riscv32imc-unknown-none-elf
+```


### PR DESCRIPTION
## 概要
Issue #39 のフォローアップとして、ESP32-C3導線の CI 監視と手順ドキュメントを追加します。

このPRは #40 の上に積む小さなPRです（stacked PR）。

## 変更内容
- GitHub Actions に `Build ESP32-C3` ジョブを追加
  - `riscv32imc-unknown-none-elf` ターゲットを追加して `platform-esp32` をクロスビルド
- README を更新
  - 高速デプロイループの説明
  - ESP32-C3 実行手順と前提条件（Rust 1.82+）
- `scripts/README.md` を更新
  - `dev-loop.sh` の使い方と前提条件を追加

## 影響範囲
- CI設定: `.github/workflows/ci.yml`
- ドキュメント: `README.md`, `scripts/README.md`

## テスト証跡
- `cargo test --all --quiet` : 成功
- `cargo clippy --all --all-targets -- -D warnings` : 成功
- `cargo +1.82.0 build -p platform-esp32 --release --target riscv32imc-unknown-none-elf --no-default-features --features esp32c3` : 成功

## ロールバック手順
- 本PRを `Revert` すると、CI追加ジョブとドキュメント変更のみを切り戻せます。

## 関連
- Refs #39
- Depends on #40
