### PR TITLE
feat: enhance dashboard with sparklines, dark mode, and add ImuLoggerApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.0] - 2026-04-05
+
+sim-to-real スターターキット完成。ESP32 実機 toolchain 対応、web ダッシュボード強化、IMU ロギングアプリ追加。
+
 ### Added
 - `reference-drivers` を追加し、`BME280` / `LCD1602` の board 非依存 driver を `platform-esp32` から切り出した
 - `platform-avr` を追加し、AVR 系 board 向けの generic GPIO / I2C adapter と host integration test を用意した
@@ -32,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `crates/platform-esp32/README.md` を追加し、original ESP32 向け toolchain と最小確認手順を整理した
 - `firmware/original-esp32-bringup` を追加し、LED only / real I2C の実機 bring-up 雛形を用意した
 - `docs/images/original-esp32-wiring.svg` と `docs/images/original-esp32-bringup-flow.svg` を追加した
+- **[#55]** web ダッシュボード (`device-dashboard-web`) に SVG スパークライン（温度・湿度・気圧・距離・加速度Z の直近60サンプル）を追加した
+- **[#55]** web ダッシュボードにダークモード（CSS カスタムプロパティ + `localStorage` 永続化）を追加した
+- **[#55]** web ダッシュボードに接続ステータスバー（オンライン/オフライン/エラードット + タイムスタンプ）を追加した
+- **[#55]** web ダッシュボードにリフレッシュ間隔セレクタ（250 ms〜5 s）と一時停止/再開ボタンを追加した
+- **[#55]** `core-app` に `ImuLoggerApp<IMU>` を追加した。`ImuSensor` trait のみに依存する `no_std` 対応アプリで、モーション検出とリングバッファログを備える
 
 ### Changed
 - `platform-esp32` は board adapter に集中し、`BME280` / `LCD1602` driver は `reference-drivers` から re-export する構成になった
@@ -48,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `platform-esp32` の GPIO / I2C アダプタが `hal-api` のエラー型へ正規化するようになり、`core-app::App` と直接接続できるようになった
 
 ### Fixed
-- 今後修正されるバグ
+- `device-dashboard-web`: `body.as_bytes().len()` → `body.len()` (clippy lint)
 
 ---
 

--- a/crates/core-app/imu_logger.rs
+++ b/crates/core-app/imu_logger.rs
@@ -1,0 +1,255 @@
+//! IMU logging application — `ImuSensor` を使ったデータ収集とモーション検出。
+//!
+//! センサからの読み取りを一定間隔で行い、直近のサンプルをリングバッファに保持します。
+//! 静止状態から逸脱したときに `motion_detected` フラグを立てます。
+//!
+//! # Examples
+//!
+//! ```
+//! use core_app::imu_logger::{ImuLoggerApp, ImuLoggerConfig};
+//! use hal_api::imu::{ImuReading, ImuSensor};
+//!
+//! struct MockImu;
+//! impl ImuSensor for MockImu {
+//!     type Error = ();
+//!     fn read_imu(&mut self) -> Result<ImuReading, ()> {
+//!         Ok(ImuReading::new([0, 0, 1000], [0, 0, 0], Some(2500)))
+//!     }
+//! }
+//!
+//! let mut app = ImuLoggerApp::new(MockImu);
+//! for _ in 0..10 {
+//!     app.tick().unwrap();
+//! }
+//! assert!(app.last_reading().is_some());
+//! ```
+
+use hal_api::imu::{ImuReading, ImuSensor};
+use heapless::Vec;
+
+#[cfg(test)]
+extern crate std;
+
+/// `ImuLoggerApp` の設定。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImuLoggerConfig {
+    /// センサを読み取る tick 間隔。
+    pub sample_period_ticks: u32,
+    /// 静止状態 (1 g) からの逸脱検出しきい値 (mg)。
+    pub motion_threshold_mg: u16,
+}
+
+impl Default for ImuLoggerConfig {
+    fn default() -> Self {
+        Self {
+            sample_period_ticks: 10,
+            motion_threshold_mg: 200,
+        }
+    }
+}
+
+/// `ImuLoggerApp` が返すエラー型。
+#[derive(Debug, PartialEq, Eq)]
+pub enum ImuLoggerError<E> {
+    Sensor(E),
+}
+
+/// 直近の IMU サンプルを保持するリングバッファの容量。
+pub const IMU_LOG_CAPACITY: usize = 10;
+
+/// IMU ロギングアプリ。
+///
+/// `tick()` を毎ループ呼び出すことで、`sample_period_ticks` ごとにセンサを読み取り、
+/// 直近 [`IMU_LOG_CAPACITY`] 件の読み取り結果を保持します。
+pub struct ImuLoggerApp<IMU> {
+    imu: IMU,
+    tick_count: u32,
+    config: ImuLoggerConfig,
+    last_reading: Option<ImuReading>,
+    log: Vec<ImuReading, IMU_LOG_CAPACITY>,
+    motion_detected: bool,
+}
+
+impl<IMU> ImuLoggerApp<IMU>
+where
+    IMU: ImuSensor,
+{
+    pub fn new(imu: IMU) -> Self {
+        Self::new_with_config(imu, ImuLoggerConfig::default())
+    }
+
+    pub fn new_with_config(imu: IMU, config: ImuLoggerConfig) -> Self {
+        Self {
+            imu,
+            tick_count: 0,
+            config,
+            last_reading: None,
+            log: Vec::new(),
+            motion_detected: false,
+        }
+    }
+
+    /// 1 tick 進める。`sample_period_ticks` の倍数 tick でセンサを読み取る。
+    pub fn tick(&mut self) -> Result<(), ImuLoggerError<IMU::Error>> {
+        self.tick_count += 1;
+        let period = self.config.sample_period_ticks.max(1);
+        if self.tick_count % period == 0 {
+            let reading = self.imu.read_imu().map_err(ImuLoggerError::Sensor)?;
+            self.motion_detected =
+                detect_motion(&reading, self.config.motion_threshold_mg);
+            if self.log.is_full() {
+                self.log.remove(0);
+            }
+            self.log.push(reading).ok();
+            self.last_reading = Some(reading);
+        }
+        Ok(())
+    }
+
+    /// 最新の読み取り結果を返す。まだ1回も読み取っていなければ `None`。
+    pub fn last_reading(&self) -> Option<ImuReading> {
+        self.last_reading
+    }
+
+    /// モーション検出フラグ。最後の読み取りで静止状態から逸脱していれば `true`。
+    pub fn motion_detected(&self) -> bool {
+        self.motion_detected
+    }
+
+    /// 直近のサンプルログ（最大 [`IMU_LOG_CAPACITY`] 件、古い順）。
+    pub fn log(&self) -> &[ImuReading] {
+        &self.log
+    }
+
+    pub fn tick_count(&self) -> u32 {
+        self.tick_count
+    }
+}
+
+/// 加速度ベクトルの大きさが 1 g から `threshold_mg` 以上離れているか判定する。
+///
+/// `|mag(accel) - 1000 mg| > threshold_mg` を整数演算で近似する。
+/// 具体的には `|mag² - 1g²| > threshold * 2 * 1000` を使う。
+fn detect_motion(reading: &ImuReading, threshold_mg: u16) -> bool {
+    let [ax, ay, az] = reading.accel_mg;
+    let mag_sq: i64 =
+        ax as i64 * ax as i64 + ay as i64 * ay as i64 + az as i64 * az as i64;
+    let one_g_sq: i64 = 1_000_000;
+    let diff = (mag_sq - one_g_sq).unsigned_abs();
+    diff > threshold_mg as u64 * 2_000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockImu {
+        readings: std::vec::Vec<ImuReading>,
+        index: usize,
+    }
+
+    impl MockImu {
+        fn new(readings: std::vec::Vec<ImuReading>) -> Self {
+            Self { readings, index: 0 }
+        }
+    }
+
+    impl ImuSensor for MockImu {
+        type Error = ();
+        fn read_imu(&mut self) -> Result<ImuReading, ()> {
+            let r = self.readings[self.index % self.readings.len()];
+            self.index += 1;
+            Ok(r)
+        }
+    }
+
+    fn at_rest() -> ImuReading {
+        ImuReading::new([0, 0, 1000], [0, 0, 0], Some(2500))
+    }
+
+    fn in_motion() -> ImuReading {
+        // accel magnitude >> 1g
+        ImuReading::new([800, 800, 800], [500, 0, 0], None)
+    }
+
+    #[test]
+    fn first_sample_available_after_one_period() {
+        let mut app = ImuLoggerApp::new_with_config(
+            MockImu::new(std::vec![at_rest()]),
+            ImuLoggerConfig {
+                sample_period_ticks: 5,
+                ..Default::default()
+            },
+        );
+        for _ in 0..4 {
+            app.tick().unwrap();
+            assert!(app.last_reading().is_none());
+        }
+        app.tick().unwrap();
+        assert_eq!(app.last_reading(), Some(at_rest()));
+        assert_eq!(app.tick_count(), 5);
+    }
+
+    #[test]
+    fn log_fills_up_and_drops_oldest() {
+        let readings = std::vec![at_rest(); IMU_LOG_CAPACITY + 3];
+        let mut app = ImuLoggerApp::new_with_config(
+            MockImu::new(readings),
+            ImuLoggerConfig {
+                sample_period_ticks: 1,
+                ..Default::default()
+            },
+        );
+        for _ in 0..(IMU_LOG_CAPACITY + 3) {
+            app.tick().unwrap();
+        }
+        assert_eq!(app.log().len(), IMU_LOG_CAPACITY);
+    }
+
+    #[test]
+    fn motion_detected_when_accel_deviates_from_1g() {
+        let mut app = ImuLoggerApp::new_with_config(
+            MockImu::new(std::vec![in_motion()]),
+            ImuLoggerConfig {
+                sample_period_ticks: 1,
+                motion_threshold_mg: 200,
+            },
+        );
+        app.tick().unwrap();
+        assert!(app.motion_detected());
+    }
+
+    #[test]
+    fn no_motion_when_at_rest() {
+        let mut app = ImuLoggerApp::new_with_config(
+            MockImu::new(std::vec![at_rest()]),
+            ImuLoggerConfig {
+                sample_period_ticks: 1,
+                motion_threshold_mg: 200,
+            },
+        );
+        app.tick().unwrap();
+        assert!(!app.motion_detected());
+    }
+
+    #[test]
+    fn motion_threshold_respected() {
+        // 重力ベクトル方向に少しだけ傾けた状態 (50 mg ずれ)
+        let small_tilt = ImuReading::new([50, 0, 998], [0, 0, 0], None);
+        let mut app = ImuLoggerApp::new_with_config(
+            MockImu::new(std::vec![small_tilt]),
+            ImuLoggerConfig {
+                sample_period_ticks: 1,
+                motion_threshold_mg: 200,
+            },
+        );
+        app.tick().unwrap();
+        assert!(!app.motion_detected(), "small tilt should not trigger motion");
+    }
+
+    #[test]
+    fn detect_motion_fn_is_pure() {
+        assert!(!detect_motion(&at_rest(), 200));
+        assert!(detect_motion(&in_motion(), 200));
+    }
+}

--- a/crates/core-app/imu_logger.rs
+++ b/crates/core-app/imu_logger.rs
@@ -95,8 +95,7 @@ where
         let period = self.config.sample_period_ticks.max(1);
         if self.tick_count % period == 0 {
             let reading = self.imu.read_imu().map_err(ImuLoggerError::Sensor)?;
-            self.motion_detected =
-                detect_motion(&reading, self.config.motion_threshold_mg);
+            self.motion_detected = detect_motion(&reading, self.config.motion_threshold_mg);
             if self.log.is_full() {
                 self.log.remove(0);
             }
@@ -132,8 +131,7 @@ where
 /// 具体的には `|mag² - 1g²| > threshold * 2 * 1000` を使う。
 fn detect_motion(reading: &ImuReading, threshold_mg: u16) -> bool {
     let [ax, ay, az] = reading.accel_mg;
-    let mag_sq: i64 =
-        ax as i64 * ax as i64 + ay as i64 * ay as i64 + az as i64 * az as i64;
+    let mag_sq: i64 = ax as i64 * ax as i64 + ay as i64 * ay as i64 + az as i64 * az as i64;
     let one_g_sq: i64 = 1_000_000;
     let diff = (mag_sq - one_g_sq).unsigned_abs();
     diff > threshold_mg as u64 * 2_000
@@ -244,7 +242,10 @@ mod tests {
             },
         );
         app.tick().unwrap();
-        assert!(!app.motion_detected(), "small tilt should not trigger motion");
+        assert!(
+            !app.motion_detected(),
+            "small tilt should not trigger motion"
+        );
     }
 
     #[test]

--- a/crates/core-app/lib.rs
+++ b/crates/core-app/lib.rs
@@ -66,6 +66,7 @@ use hal_api::gpio::OutputPin;
 use hal_api::i2c::I2cBus;
 
 pub mod climate_display;
+pub mod imu_logger;
 
 #[cfg(test)]
 extern crate std;

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -161,7 +161,7 @@ fn json_string(value: &str) -> String {
 }
 
 pub fn dashboard_html() -> &'static str {
-    r#"<!doctype html>
+    r##"<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -170,29 +170,83 @@ pub fn dashboard_html() -> &'static str {
   <style>
     :root {
       --bg: #f6f1e7;
-      --paper: rgba(255, 252, 247, 0.88);
+      --paper: rgba(255,252,247,0.88);
       --ink: #1c2b28;
       --muted: #6c756f;
       --accent: #0f7c6b;
       --accent-2: #d95f3d;
-      --line: rgba(28, 43, 40, 0.12);
-      --shadow: 0 24px 80px rgba(33, 41, 38, 0.12);
+      --line: rgba(28,43,40,0.12);
+      --shadow: 0 24px 80px rgba(33,41,38,0.12);
+      --status-ok: #0f7c6b;
+      --status-err: #d95f3d;
+      --spark: #0f7c6b;
+      --grad1: rgba(15,124,107,0.18);
+      --grad2: rgba(217,95,61,0.12);
+      --grad3: #faf5eb;
+    }
+    .dark {
+      --bg: #0e1614;
+      --paper: rgba(20,30,28,0.92);
+      --ink: #dde8e4;
+      --muted: #7a9990;
+      --accent: #3dcfb8;
+      --accent-2: #f07850;
+      --line: rgba(221,232,228,0.1);
+      --shadow: 0 24px 80px rgba(0,0,0,0.4);
+      --status-ok: #3dcfb8;
+      --status-err: #f07850;
+      --spark: #3dcfb8;
+      --grad1: rgba(61,207,184,0.1);
+      --grad2: rgba(240,120,80,0.08);
+      --grad3: #0a1210;
     }
     * { box-sizing: border-box; }
+    html { transition: color 0.25s, background 0.25s; }
     body {
       margin: 0;
       font-family: "IBM Plex Sans", "Avenir Next", sans-serif;
       color: var(--ink);
       background:
-        radial-gradient(circle at top left, rgba(15,124,107,0.18), transparent 28rem),
-        radial-gradient(circle at top right, rgba(217,95,61,0.12), transparent 24rem),
-        linear-gradient(180deg, #faf5eb 0%, var(--bg) 100%);
+        radial-gradient(circle at top left, var(--grad1), transparent 28rem),
+        radial-gradient(circle at top right, var(--grad2), transparent 24rem),
+        linear-gradient(180deg, var(--grad3) 0%, var(--bg) 100%);
       min-height: 100vh;
     }
     .shell {
       width: min(1220px, calc(100vw - 32px));
-      margin: 24px auto 40px;
+      margin: 0 auto 40px;
     }
+    /* ── Status bar ── */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 2px;
+      font-size: 13px;
+      flex-wrap: wrap;
+    }
+    .sdot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      background: var(--muted);
+      flex-shrink: 0;
+      transition: background 0.3s, box-shadow 0.3s;
+    }
+    .sdot.ok  { background: var(--status-ok);  box-shadow: 0 0 6px var(--status-ok); }
+    .sdot.err { background: var(--status-err); box-shadow: 0 0 6px var(--status-err); }
+    .stext { color: var(--muted); }
+    .serr  { color: var(--status-err); font-family: monospace; font-size: 12px;
+             max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .ctrls { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+    select, .btn {
+      font-family: inherit; font-size: 13px;
+      border: 1px solid var(--line); border-radius: 8px;
+      padding: 5px 10px;
+      background: var(--paper); color: var(--ink);
+      cursor: pointer; transition: background 0.2s;
+    }
+    select:hover, .btn:hover { background: rgba(15,124,107,0.1); }
+    /* ── Hero ── */
     .hero {
       display: grid;
       grid-template-columns: 2fr 1fr;
@@ -206,161 +260,105 @@ pub fn dashboard_html() -> &'static str {
       box-shadow: var(--shadow);
       backdrop-filter: blur(18px);
     }
-    .hero-main {
-      padding: 24px 24px 18px;
-      position: relative;
-      overflow: hidden;
-    }
+    .hero-main { padding: 24px 24px 18px; position: relative; overflow: hidden; }
     .hero-main::after {
-      content: "";
-      position: absolute;
-      inset: auto -12% -40% auto;
-      width: 220px;
-      height: 220px;
+      content: ""; position: absolute; inset: auto -12% -40% auto;
+      width: 220px; height: 220px;
       background: radial-gradient(circle, rgba(15,124,107,0.18), transparent 65%);
       pointer-events: none;
     }
     .kicker {
-      font-size: 12px;
-      letter-spacing: 0.18em;
-      text-transform: uppercase;
-      color: var(--accent);
-      margin-bottom: 10px;
+      font-size: 12px; letter-spacing: 0.18em;
+      text-transform: uppercase; color: var(--accent); margin-bottom: 10px;
     }
     .hero-title {
-      font-family: "Iowan Old Style", "Palatino Linotype", serif;
-      font-size: clamp(34px, 5vw, 58px);
-      line-height: 0.95;
-      margin: 0 0 10px;
+      font-family: "Iowan Old Style","Palatino Linotype",serif;
+      font-size: clamp(34px,5vw,58px); line-height: 0.95; margin: 0 0 10px;
     }
-    .hero-sub {
-      color: var(--muted);
-      max-width: 42rem;
-      line-height: 1.5;
-    }
-    .hero-meta {
-      display: flex;
-      gap: 10px;
-      flex-wrap: wrap;
-      margin-top: 18px;
-    }
+    .hero-sub { color: var(--muted); max-width: 42rem; line-height: 1.5; }
+    .hero-meta { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
     .chip {
-      padding: 8px 12px;
-      border-radius: 999px;
-      background: rgba(15,124,107,0.08);
-      color: var(--ink);
-      font-size: 13px;
+      padding: 8px 12px; border-radius: 999px;
+      background: rgba(15,124,107,0.08); color: var(--ink); font-size: 13px;
     }
-    .hero-side {
-      padding: 20px;
-      display: grid;
-      align-content: space-between;
-    }
-    .hero-side .label {
-      color: var(--muted);
-      font-size: 13px;
-      margin-bottom: 6px;
-    }
-    .hero-side .value {
-      font-family: "Iowan Old Style", serif;
-      font-size: 36px;
-      margin-bottom: 14px;
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(12, 1fr);
-      gap: 16px;
-    }
-    .card {
-      padding: 18px;
-      min-height: 180px;
-    }
-    .span-4 { grid-column: span 4; }
-    .span-6 { grid-column: span 6; }
-    .span-8 { grid-column: span 8; }
+    .hero-side { padding: 20px; display: grid; align-content: space-between; }
+    .hero-side .label { color: var(--muted); font-size: 13px; margin-bottom: 6px; }
+    .hero-side .big   { font-family: "Iowan Old Style",serif; font-size: 36px; margin-bottom: 14px; }
+    /* ── Grid ── */
+    .grid { display: grid; grid-template-columns: repeat(12,1fr); gap: 16px; }
+    .card { padding: 18px; min-height: 180px; }
+    .span-4  { grid-column: span 4; }
+    .span-6  { grid-column: span 6; }
+    .span-8  { grid-column: span 8; }
     .span-12 { grid-column: span 12; }
-    h2 {
-      margin: 0 0 12px;
-      font-size: 18px;
-    }
-    .metric-row {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 10px;
-    }
-    .metric {
-      padding: 12px;
-      border-radius: 16px;
-      background: rgba(28,43,40,0.04);
-    }
+    h2 { margin: 0 0 12px; font-size: 18px; }
+    /* ── Metric ── */
+    .metric-row { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; }
+    .metric { padding: 12px; border-radius: 16px; background: rgba(28,43,40,0.04); }
     .metric .name {
-      color: var(--muted);
-      font-size: 12px;
-      margin-bottom: 6px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
+      color: var(--muted); font-size: 12px; margin-bottom: 4px;
+      text-transform: uppercase; letter-spacing: 0.08em;
     }
-    .metric .value {
-      font-size: 24px;
-      font-weight: 700;
+    .metric .val { font-size: 22px; font-weight: 700; }
+    /* ── Sparkline ── */
+    .spark-wrap { margin-top: 8px; }
+    svg.spark {
+      display: block; width: 100%; height: 34px; overflow: visible;
     }
+    svg.spark polyline {
+      fill: none; stroke: var(--spark); stroke-width: 1.8;
+      stroke-linejoin: round; stroke-linecap: round;
+    }
+    /* ── LCD ── */
     .lcd {
-      display: inline-block;
-      padding: 16px 18px;
-      border-radius: 18px;
-      background: linear-gradient(180deg, #9bc39f 0%, #84b18a 100%);
-      color: #112315;
-      font-family: "IBM Plex Mono", "Menlo", monospace;
-      font-size: 18px;
-      box-shadow: inset 0 0 0 1px rgba(17,35,21,0.16);
+      display: inline-block; padding: 16px 18px; border-radius: 18px;
+      background: linear-gradient(180deg,#9bc39f 0%,#84b18a 100%);
+      color: #112315; font-family: "IBM Plex Mono","Menlo",monospace;
+      font-size: 18px; box-shadow: inset 0 0 0 1px rgba(17,35,21,0.16);
     }
     .lcd-line { white-space: pre; }
-    .wiring {
-      font-family: "IBM Plex Mono", monospace;
-      white-space: pre-wrap;
-      line-height: 1.45;
-      font-size: 14px;
-    }
-    .ops {
-      margin: 0;
-      padding: 0;
-      list-style: none;
-      font-family: "IBM Plex Mono", monospace;
-      font-size: 13px;
-    }
-    .ops li {
-      padding: 8px 0;
-      border-bottom: 1px solid var(--line);
-    }
-    .axis {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 8px;
-    }
-    .axis div {
-      padding: 10px;
-      border-radius: 14px;
-      background: rgba(217,95,61,0.07);
-    }
-    .motor {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 12px;
-    }
-    .footer {
-      margin-top: 18px;
-      color: var(--muted);
-      font-size: 13px;
-    }
+    /* ── Wiring / I2C ── */
+    .wiring { font-family: "IBM Plex Mono",monospace; white-space: pre-wrap; line-height: 1.45; font-size: 13px; }
+    .ops { margin: 0; padding: 0; list-style: none; font-family: "IBM Plex Mono",monospace; font-size: 13px; }
+    .ops li { padding: 8px 0; border-bottom: 1px solid var(--line); }
+    /* ── IMU axes ── */
+    .axis { display: grid; grid-template-columns: repeat(3,1fr); gap: 8px; }
+    .axis div { padding: 10px; border-radius: 14px; background: rgba(217,95,61,0.07); }
+    /* ── Motor ── */
+    .motor { display: grid; grid-template-columns: repeat(2,1fr); gap: 12px; }
+    /* ── Footer ── */
+    .footer { margin-top: 18px; color: var(--muted); font-size: 13px; }
+    /* ── Responsive ── */
     @media (max-width: 980px) {
-      .hero, .grid { grid-template-columns: 1fr; }
-      .span-4, .span-6, .span-8, .span-12 { grid-column: span 1; }
-      .metric-row, .motor, .axis { grid-template-columns: 1fr; }
+      .hero,.grid { grid-template-columns: 1fr; }
+      .span-4,.span-6,.span-8,.span-12 { grid-column: span 1; }
+      .metric-row,.motor,.axis { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
   <main class="shell">
+
+    <!-- Status / control bar -->
+    <div class="status-bar">
+      <span class="sdot" id="sdot"></span>
+      <span class="stext" id="stext">connecting&#x2026;</span>
+      <span class="serr"  id="serr"></span>
+      <div class="ctrls">
+        <label for="isel" style="color:var(--muted)">Refresh</label>
+        <select id="isel">
+          <option value="250">250 ms</option>
+          <option value="500" selected>500 ms</option>
+          <option value="1000">1 s</option>
+          <option value="2000">2 s</option>
+          <option value="5000">5 s</option>
+        </select>
+        <button class="btn" id="pbtn">&#x23F8; Pause</button>
+        <button class="btn" id="tbtn">&#x1F319; Dark</button>
+      </div>
+    </div>
+
+    <!-- Hero -->
     <section class="hero">
       <article class="panel hero-main">
         <div class="kicker">mcu-hal-sim-rs</div>
@@ -378,23 +376,52 @@ pub fn dashboard_html() -> &'static str {
       <aside class="panel hero-side">
         <div>
           <div class="label">Distance</div>
-          <div class="value" id="distance-value">-- mm</div>
+          <div class="big" id="distance-value">-- mm</div>
           <div class="label">Servo</div>
-          <div class="value" id="servo-value">-- deg</div>
+          <div class="big" id="servo-value">-- deg</div>
         </div>
         <div class="label">Live polling from <code>/api/state</code></div>
       </aside>
     </section>
 
+    <!-- Grid -->
     <section class="grid">
+
+      <!-- Climate -->
       <article class="panel card span-6">
         <h2>Climate</h2>
         <div class="metric-row">
-          <div class="metric"><div class="name">Temp</div><div class="value" id="temp-value">--</div></div>
-          <div class="metric"><div class="name">Humidity</div><div class="value" id="hum-value">--</div></div>
-          <div class="metric"><div class="name">Pressure</div><div class="value" id="press-value">--</div></div>
+          <div class="metric">
+            <div class="name">Temp</div>
+            <div class="val" id="temp-value">--</div>
+            <div class="spark-wrap">
+              <svg class="spark" id="spark-temp" viewBox="0 0 100 30" preserveAspectRatio="none">
+                <polyline points=""/>
+              </svg>
+            </div>
+          </div>
+          <div class="metric">
+            <div class="name">Humidity</div>
+            <div class="val" id="hum-value">--</div>
+            <div class="spark-wrap">
+              <svg class="spark" id="spark-hum" viewBox="0 0 100 30" preserveAspectRatio="none">
+                <polyline points=""/>
+              </svg>
+            </div>
+          </div>
+          <div class="metric">
+            <div class="name">Pressure</div>
+            <div class="val" id="press-value">--</div>
+            <div class="spark-wrap">
+              <svg class="spark" id="spark-press" viewBox="0 0 100 30" preserveAspectRatio="none">
+                <polyline points=""/>
+              </svg>
+            </div>
+          </div>
         </div>
       </article>
+
+      <!-- LCD -->
       <article class="panel card span-6">
         <h2>LCD</h2>
         <div class="lcd">
@@ -404,103 +431,216 @@ pub fn dashboard_html() -> &'static str {
         <div class="footer">Physical LCD frame decoded from backpack traffic.</div>
       </article>
 
+      <!-- HC-SR04 -->
       <article class="panel card span-4">
         <h2>HC-SR04</h2>
         <div class="metric">
           <div class="name" id="distance-sensor-name">Distance Sensor</div>
-          <div class="value" id="distance-metric">-- mm</div>
+          <div class="val" id="distance-metric">-- mm</div>
+          <div class="spark-wrap">
+            <svg class="spark" id="spark-dist" viewBox="0 0 100 30" preserveAspectRatio="none">
+              <polyline points=""/>
+            </svg>
+          </div>
         </div>
       </article>
+
+      <!-- MPU6050 -->
       <article class="panel card span-4">
         <h2>MPU6050</h2>
         <div class="axis">
-          <div><div class="name">Accel X</div><div class="value" id="accel-x">--</div></div>
-          <div><div class="name">Accel Y</div><div class="value" id="accel-y">--</div></div>
-          <div><div class="name">Accel Z</div><div class="value" id="accel-z">--</div></div>
-          <div><div class="name">Gyro X</div><div class="value" id="gyro-x">--</div></div>
-          <div><div class="name">Gyro Y</div><div class="value" id="gyro-y">--</div></div>
-          <div><div class="name">Gyro Z</div><div class="value" id="gyro-z">--</div></div>
+          <div><div class="name">Accel X</div><div class="val" id="accel-x">--</div></div>
+          <div><div class="name">Accel Y</div><div class="val" id="accel-y">--</div></div>
+          <div><div class="name">Accel Z</div><div class="val" id="accel-z">--</div></div>
+          <div><div class="name">Gyro X</div><div class="val" id="gyro-x">--</div></div>
+          <div><div class="name">Gyro Y</div><div class="val" id="gyro-y">--</div></div>
+          <div><div class="name">Gyro Z</div><div class="val" id="gyro-z">--</div></div>
+        </div>
+        <div class="spark-wrap" style="margin-top:10px">
+          <div class="name" style="color:var(--muted);font-size:11px;margin-bottom:3px">Accel Z (mg)</div>
+          <svg class="spark" id="spark-accelz" viewBox="0 0 100 30" preserveAspectRatio="none">
+            <polyline points=""/>
+          </svg>
         </div>
       </article>
+
+      <!-- Motor Driver -->
       <article class="panel card span-4">
         <h2>Motor Driver</h2>
         <div class="motor">
           <div class="metric">
-            <div class="name">Left Channel</div>
-            <div class="value" id="motor-left">--</div>
+            <div class="name">Left</div>
+            <div class="val" id="motor-left">--</div>
           </div>
           <div class="metric">
-            <div class="name">Right Channel</div>
-            <div class="value" id="motor-right">--</div>
+            <div class="name">Right</div>
+            <div class="val" id="motor-right">--</div>
           </div>
         </div>
       </article>
 
+      <!-- Wiring -->
       <article class="panel card span-4">
         <h2>Wiring</h2>
         <div class="wiring" id="wiring-view"></div>
       </article>
+
+      <!-- I2C Activity -->
       <article class="panel card span-8">
         <h2>I2C Activity</h2>
         <ul class="ops" id="i2c-ops"></ul>
       </article>
+
     </section>
   </main>
 
   <script>
-    const fmt = (value, suffix = "") => value == null ? "--" : `${value}${suffix}`;
-    const lcdLines = ["lcd-line-1", "lcd-line-2"].map(id => document.getElementById(id));
+    // ── History ring buffers ──
+    const HIST = 60;
+    const hist = { temp:[], hum:[], press:[], dist:[], accelz:[] };
+    function push(key, v) {
+      if (v == null) return;
+      hist[key].push(v);
+      if (hist[key].length > HIST) hist[key].shift();
+    }
+
+    // ── SVG sparkline ──
+    function sparkline(id, data) {
+      if (data.length < 2) return;
+      const svg = document.getElementById(id);
+      if (!svg) return;
+      const W = 100, H = 30, PAD = 0.1;
+      const lo = Math.min(...data), hi = Math.max(...data);
+      const range = hi - lo || 1;
+      const pts = data.map((v, i) => {
+        const x = (i / (data.length - 1)) * W;
+        const y = H - PAD * H - ((v - lo) / range) * H * (1 - 2 * PAD);
+        return x.toFixed(1) + "," + y.toFixed(1);
+      }).join(" ");
+      svg.querySelector("polyline").setAttribute("points", pts);
+    }
+
+    // ── Status bar ──
+    let lastOkMs = null, errCount = 0;
+    function setOk() {
+      const now = Date.now();
+      const ago = lastOkMs ? (now - lastOkMs) + " ms ago" : "just now";
+      lastOkMs = now; errCount = 0;
+      document.getElementById("sdot").className = "sdot ok";
+      document.getElementById("stext").textContent = "Online \u00B7 updated " + ago;
+      document.getElementById("serr").textContent = "";
+    }
+    function setErr(msg) {
+      errCount++;
+      document.getElementById("sdot").className = "sdot err";
+      document.getElementById("stext").textContent = "Error \u00D7" + errCount;
+      document.getElementById("serr").textContent = msg || "";
+    }
+
+    // ── DOM helpers ──
+    const $ = id => document.getElementById(id);
+    const fmt = (v, sfx) => v == null ? "--" : v + sfx;
+    const lcdLines = ["lcd-line-1","lcd-line-2"].map(id => $(id));
+
+    // ── Main refresh ──
+    let paused = false;
     async function refresh() {
-      const response = await fetch("/api/state");
-      const state = await response.json();
+      if (paused) return;
+      try {
+        const r = await fetch("/api/state");
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        const s = await r.json();
 
-      document.getElementById("board-name").textContent = state.board_name;
-      document.getElementById("mcu-name").textContent = state.mcu_name;
-      document.getElementById("tick-chip").textContent = `tick=${state.tick}`;
-      document.getElementById("i2c-chip").textContent = `i2c ops=${state.i2c.operation_count}`;
+        $("board-name").textContent = s.board_name;
+        $("mcu-name").textContent   = s.mcu_name;
+        $("tick-chip").textContent  = "tick=" + s.tick;
+        $("i2c-chip").textContent   = "i2c ops=" + s.i2c.operation_count;
 
-      document.getElementById("temp-value").textContent = fmt(state.climate.temperature_c, " C");
-      document.getElementById("hum-value").textContent = fmt(state.climate.humidity_percent, " %");
-      document.getElementById("press-value").textContent = fmt(state.climate.pressure_pa, " Pa");
+        $("temp-value").textContent  = fmt(s.climate.temperature_c,    " \u00B0C");
+        $("hum-value").textContent   = fmt(s.climate.humidity_percent, " %");
+        $("press-value").textContent = fmt(s.climate.pressure_pa,      " Pa");
+        lcdLines[0].textContent = s.climate.physical_lcd_frame[0];
+        lcdLines[1].textContent = s.climate.physical_lcd_frame[1];
 
-      lcdLines[0].textContent = state.climate.physical_lcd_frame[0];
-      lcdLines[1].textContent = state.climate.physical_lcd_frame[1];
+        $("distance-value").textContent       = fmt(s.distance.distance_mm, " mm");
+        $("distance-metric").textContent      = fmt(s.distance.distance_mm, " mm");
+        $("distance-sensor-name").textContent = s.distance.sensor_name;
+        $("servo-value").textContent          = s.servo.angle_degrees + " deg";
 
-      document.getElementById("distance-value").textContent = fmt(state.distance.distance_mm, " mm");
-      document.getElementById("distance-metric").textContent = fmt(state.distance.distance_mm, " mm");
-      document.getElementById("distance-sensor-name").textContent = state.distance.sensor_name;
-      document.getElementById("servo-value").textContent = `${state.servo.angle_degrees} deg`;
+        $("accel-x").textContent = s.imu.accel_mg[0]  + " mg";
+        $("accel-y").textContent = s.imu.accel_mg[1]  + " mg";
+        $("accel-z").textContent = s.imu.accel_mg[2]  + " mg";
+        $("gyro-x").textContent  = s.imu.gyro_mdps[0] + " mdps";
+        $("gyro-y").textContent  = s.imu.gyro_mdps[1] + " mdps";
+        $("gyro-z").textContent  = s.imu.gyro_mdps[2] + " mdps";
 
-      document.getElementById("accel-x").textContent = `${state.imu.accel_mg[0]} mg`;
-      document.getElementById("accel-y").textContent = `${state.imu.accel_mg[1]} mg`;
-      document.getElementById("accel-z").textContent = `${state.imu.accel_mg[2]} mg`;
-      document.getElementById("gyro-x").textContent = `${state.imu.gyro_mdps[0]} mdps`;
-      document.getElementById("gyro-y").textContent = `${state.imu.gyro_mdps[1]} mdps`;
-      document.getElementById("gyro-z").textContent = `${state.imu.gyro_mdps[2]} mdps`;
+        $("motor-left").textContent  = s.motor_driver.left.direction  + " " + s.motor_driver.left.duty_percent  + "%";
+        $("motor-right").textContent = s.motor_driver.right.direction + " " + s.motor_driver.right.duty_percent + "%";
 
-      document.getElementById("motor-left").textContent =
-        `${state.motor_driver.left.direction} ${state.motor_driver.left.duty_percent}%`;
-      document.getElementById("motor-right").textContent =
-        `${state.motor_driver.right.direction} ${state.motor_driver.right.duty_percent}%`;
+        $("wiring-view").textContent = s.wiring.diagram_lines.join("\n");
 
-      document.getElementById("wiring-view").textContent =
-        state.wiring.diagram_lines.join("\n");
+        const ops = $("i2c-ops");
+        ops.innerHTML = "";
+        for (const line of s.i2c.recent_operations) {
+          const li = document.createElement("li");
+          li.textContent = line;
+          ops.appendChild(li);
+        }
 
-      const ops = document.getElementById("i2c-ops");
-      ops.innerHTML = "";
-      for (const line of state.i2c.recent_operations) {
-        const li = document.createElement("li");
-        li.textContent = line;
-        ops.appendChild(li);
+        // history + sparklines
+        push("temp",   s.climate.temperature_c);
+        push("hum",    s.climate.humidity_percent);
+        push("press",  s.climate.pressure_pa);
+        push("dist",   s.distance.distance_mm);
+        push("accelz", s.imu.accel_mg[2]);
+        sparkline("spark-temp",   hist.temp);
+        sparkline("spark-hum",    hist.hum);
+        sparkline("spark-press",  hist.press);
+        sparkline("spark-dist",   hist.dist);
+        sparkline("spark-accelz", hist.accelz);
+
+        setOk();
+      } catch(e) {
+        setErr(e.message);
       }
     }
 
+    // ── Interval control ──
+    let timerId = null;
+    function startTimer(ms) {
+      clearInterval(timerId);
+      timerId = setInterval(refresh, ms);
+    }
+    $("isel").addEventListener("change", e => startTimer(+e.target.value));
+
+    // ── Pause/resume ──
+    $("pbtn").addEventListener("click", () => {
+      paused = !paused;
+      $("pbtn").innerHTML = paused ? "&#x25B6; Resume" : "&#x23F8; Pause";
+      if (paused) {
+        $("sdot").className = "sdot";
+        $("stext").textContent = "Paused";
+      }
+    });
+
+    // ── Dark mode ──
+    function applyTheme(dark) {
+      document.documentElement.classList.toggle("dark", dark);
+      $("tbtn").innerHTML = dark ? "&#x2600; Light" : "&#x1F319; Dark";
+      try { localStorage.setItem("dash-theme", dark ? "dark" : "light"); } catch(_) {}
+    }
+    $("tbtn").addEventListener("click", () =>
+      applyTheme(!document.documentElement.classList.contains("dark"))
+    );
+    try { applyTheme(localStorage.getItem("dash-theme") === "dark"); } catch(_) {}
+
+    // ── Boot ──
     refresh();
-    setInterval(refresh, 500);
+    startTimer(500);
   </script>
 </body>
 </html>
-"#
+"##
 }
 
 #[cfg(test)]
@@ -512,6 +652,26 @@ mod tests {
         let html = dashboard_html();
         assert!(html.contains("/api/state"));
         assert!(html.contains("Device Dashboard"));
+    }
+
+    #[test]
+    fn html_contains_dashboard_features() {
+        let html = dashboard_html();
+        // sparkline SVGs
+        assert!(html.contains("spark-temp"));
+        assert!(html.contains("spark-hum"));
+        assert!(html.contains("spark-press"));
+        assert!(html.contains("spark-dist"));
+        assert!(html.contains("spark-accelz"));
+        // dark mode
+        assert!(html.contains("dash-theme"));
+        assert!(html.contains("tbtn"));
+        // pause/interval controls
+        assert!(html.contains("pbtn"));
+        assert!(html.contains("isel"));
+        // status bar
+        assert!(html.contains("sdot"));
+        assert!(html.contains("stext"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

このPRは以下の2つの改善を含みます。

---

### 1. Webダッシュボード強化 (`platform-pc-sim`)

- **SVGスパークライン**: 温度・湿度・気圧・距離・加速度Zの直近60サンプルをリアルタイムグラフ表示
- **ダークモード**: CSSカスタムプロパティ + `localStorage` 永続化、トグルボタンで切り替え
- **接続ステータスバー**: オンライン/オフライン/エラーをドット＋タイムスタンプで表示
- **リフレッシュ間隔の設定**: 250ms〜5s をセレクトボックスで変更可能
- **一時停止/再開ボタン**: ポーリングを止めてスナップショット確認が可能

### 2. IMUロギングアプリ追加 (`core-app`)

- `ImuLoggerApp<IMU>`: `ImuSensor` trait のみに依存した `no_std` 対応アプリ
- 設定可能な `sample_period_ticks` / `motion_threshold_mg`
- 直近10件の読み取りを `heapless::Vec` リングバッファで保持
- モーション検出: 加速度ベクトルの大きさが 1g から `threshold` 以上離れると `true`
- 6件のユニットテスト + 1件のdocテスト

---

## テスト実行方法

```bash
# ユニットテスト・docテスト
cargo test --workspace --all-targets

# Lintチェック
cargo clippy --workspace --all-targets -- -D warnings

# ダッシュボード動作確認
cargo run -p device-dashboard-web
# ブラウザで http://127.0.0.1:7878 を開く
```

## 変更ファイル

- `crates/platform-pc-sim/web_dashboard.rs` — `dashboard_html()` 全面リライト
- `crates/core-app/imu_logger.rs` — 新規追加
- `crates/core-app/lib.rs` — `pub mod imu_logger` を追加