### PR TITLE
feat: add visual hardware simulation and PCB-style wiring diagram

### DIFF
--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -20,6 +20,8 @@ use platform_pc_sim::web_dashboard::{
     I2cPanelState, ImuPanelState, MotorChannelState, MotorDriverPanelState, ServoPanelState,
     WiringPanelState,
 };
+use platform_pc_sim::wiring_config::WiringConfig;
+use platform_pc_sim::wiring_svg::wiring_svg;
 use reference_drivers::bme280::{Bme280Sensor, BME280_ADDRESS_PRIMARY};
 use reference_drivers::hc_sr04::HcSr04Sensor;
 use reference_drivers::lcd1602::{Lcd1602Display, LCD1602_ADDRESS_PRIMARY};
@@ -417,6 +419,20 @@ fn main() {
                     "application/json; charset=utf-8",
                     &payload,
                 );
+            }
+            "/api/wiring" => {
+                let payload = WiringConfig::from_board(rig.board).to_json();
+                respond(
+                    &mut stream,
+                    "200 OK",
+                    "application/json; charset=utf-8",
+                    &payload,
+                );
+            }
+            "/api/wiring/svg" => {
+                let cfg = WiringConfig::from_board(rig.board);
+                let svg = wiring_svg(&cfg);
+                respond(&mut stream, "200 OK", "image/svg+xml; charset=utf-8", &svg);
             }
             _ => respond(
                 &mut stream,

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -426,7 +426,17 @@ fn handle_test_stream(stream: &mut TcpStream) {
     });
     drop(tx);
 
+    let started = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(300);
+
     for line in rx {
+        if started.elapsed() > timeout {
+            let _ = stream.write_all(
+                b"data: [ERROR] timeout: cargo test exceeded 5 minutes\n\ndata: [DONE] exit=1\n\n",
+            );
+            let _ = child.kill();
+            return;
+        }
         let msg = format!("data: {}\n\n", line.replace('\n', " "));
         if stream.write_all(msg.as_bytes()).is_err() {
             let _ = child.kill();

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -371,6 +371,73 @@ fn respond(stream: &mut TcpStream, status: &str, content_type: &str, body: &str)
     let _ = stream.write_all(response.as_bytes());
 }
 
+/// Stream `cargo test --workspace` output as Server-Sent Events.
+///
+/// Blocks until the test process exits. Each stdout/stderr line is sent as
+/// `data: {line}\n\n`.  A final `data: [DONE] exit=N\n\n` closes the stream.
+fn handle_test_stream(stream: &mut TcpStream) {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+
+    let header = "HTTP/1.1 200 OK\r\n\
+        Content-Type: text/event-stream\r\n\
+        Cache-Control: no-cache\r\n\
+        Connection: keep-alive\r\n\
+        Access-Control-Allow-Origin: *\r\n\
+        \r\n";
+    if stream.write_all(header.as_bytes()).is_err() {
+        return;
+    }
+
+    let mut child = match Command::new("cargo")
+        .args(["test", "--workspace", "--color=never"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = stream.write_all(
+                format!("data: [ERROR] failed to spawn: {e}\n\ndata: [DONE] exit=1\n\n").as_bytes(),
+            );
+            return;
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<String>();
+    let tx_out = tx.clone();
+    let stdout = child.stdout.take().expect("stdout piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx_out.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let tx_err = tx.clone();
+    let stderr = child.stderr.take().expect("stderr piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if tx_err.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    drop(tx);
+
+    for line in rx {
+        let msg = format!("data: {}\n\n", line.replace('\n', " "));
+        if stream.write_all(msg.as_bytes()).is_err() {
+            let _ = child.kill();
+            return;
+        }
+    }
+
+    let exit_code = child.wait().map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+    let _ = stream.write_all(format!("data: [DONE] exit={exit_code}\n\n").as_bytes());
+}
+
 fn main() {
     let mut args = env::args().skip(1);
     let first = args.next();
@@ -433,6 +500,9 @@ fn main() {
                 let cfg = WiringConfig::from_board(rig.board);
                 let svg = wiring_svg(&cfg);
                 respond(&mut stream, "200 OK", "image/svg+xml; charset=utf-8", &svg);
+            }
+            "/api/test/stream" => {
+                handle_test_stream(&mut stream);
             }
             _ => respond(
                 &mut stream,

--- a/crates/platform-pc-sim/lib.rs
+++ b/crates/platform-pc-sim/lib.rs
@@ -15,3 +15,5 @@ pub mod mock_hal;
 pub mod mpu6050_mock;
 pub mod virtual_i2c;
 pub mod web_dashboard;
+pub mod wiring_config;
+pub mod wiring_svg;

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -326,6 +326,19 @@ pub fn dashboard_html() -> &'static str {
     .axis div { padding: 10px; border-radius: 14px; background: rgba(217,95,61,0.07); }
     /* ── Motor ── */
     .motor { display: grid; grid-template-columns: repeat(2,1fr); gap: 12px; }
+    /* ── Hardware Simulation ── */
+    .hw-sim-grid {
+      display: grid;
+      grid-template-columns: repeat(4,1fr);
+      gap: 24px;
+      align-items: start;
+      justify-items: center;
+    }
+    .hw-item { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .hw-name {
+      font-size: 11px; color: var(--muted);
+      text-transform: uppercase; letter-spacing: .08em;
+    }
     /* ── Footer ── */
     .footer { margin-top: 18px; color: var(--muted); font-size: 13px; }
     /* ── Responsive ── */
@@ -333,6 +346,7 @@ pub fn dashboard_html() -> &'static str {
       .hero,.grid { grid-template-columns: 1fr; }
       .span-4,.span-6,.span-8,.span-12 { grid-column: span 1; }
       .metric-row,.motor,.axis { grid-template-columns: 1fr; }
+      .hw-sim-grid { grid-template-columns: repeat(2,1fr); }
     }
   </style>
 </head>
@@ -443,6 +457,31 @@ pub fn dashboard_html() -> &'static str {
             </svg>
           </div>
         </div>
+        <!-- Sonar beam visualization -->
+        <svg id="sonar-svg" viewBox="0 0 200 76" width="100%" height="76"
+             style="margin-top:12px;overflow:visible">
+          <rect x="2" y="23" width="28" height="30" rx="3" fill="#1e2a3a" stroke="#445"/>
+          <circle cx="10" cy="38" r="5.5" fill="#1a3a5a" stroke="#5599cc"/>
+          <circle cx="22" cy="38" r="5.5" fill="#1a3a5a" stroke="#5599cc"/>
+          <!-- Ping rings (SMIL animation) -->
+          <circle cx="35" cy="38" r="8" fill="none" stroke="#4fc3f7" stroke-width="1.5">
+            <animate attributeName="r" from="8" to="54" dur="2s" repeatCount="indefinite" begin="0s"/>
+            <animate attributeName="opacity" from="0.7" to="0" dur="2s" repeatCount="indefinite" begin="0s"/>
+          </circle>
+          <circle cx="35" cy="38" r="8" fill="none" stroke="#4fc3f7" stroke-width="1.2">
+            <animate attributeName="r" from="8" to="54" dur="2s" repeatCount="indefinite" begin="0.7s"/>
+            <animate attributeName="opacity" from="0.6" to="0" dur="2s" repeatCount="indefinite" begin="0.7s"/>
+          </circle>
+          <circle cx="35" cy="38" r="8" fill="none" stroke="#4fc3f7" stroke-width="0.8">
+            <animate attributeName="r" from="8" to="54" dur="2s" repeatCount="indefinite" begin="1.4s"/>
+            <animate attributeName="opacity" from="0.5" to="0" dur="2s" repeatCount="indefinite" begin="1.4s"/>
+          </circle>
+          <line x1="35" y1="38" id="sonar-beam" x2="135" y2="38"
+                stroke="#4fc3f7" stroke-width="1" stroke-dasharray="5 3" opacity="0.55"/>
+          <circle id="sonar-echo" cx="135" cy="38" r="5.5" fill="#66bb6a"/>
+          <text id="sonar-dist-lbl" x="110" y="14" text-anchor="middle"
+                fill="#888" font-size="10" font-family="system-ui">-- mm</text>
+        </svg>
       </article>
 
       <!-- MPU6050 -->
@@ -462,6 +501,19 @@ pub fn dashboard_html() -> &'static str {
             <polyline points=""/>
           </svg>
         </div>
+        <!-- Bubble level tilt indicator -->
+        <svg id="imu-level-svg" viewBox="0 0 100 100" width="88" height="88"
+             style="margin:8px auto 0;display:block">
+          <circle cx="50" cy="50" r="42" fill="rgba(0,0,0,0.15)" stroke="#445" stroke-width="1.5"/>
+          <circle cx="50" cy="50" r="28" fill="none" stroke="#334" stroke-width="1" stroke-dasharray="3 3"/>
+          <circle cx="50" cy="50" r="3.5" fill="none" stroke="#556" stroke-width="1.5"/>
+          <line x1="50" y1="13" x2="50" y2="87" stroke="#2a3a3a" stroke-width="1" stroke-dasharray="2 4"/>
+          <line x1="13" y1="50" x2="87" y2="50" stroke="#2a3a3a" stroke-width="1" stroke-dasharray="2 4"/>
+          <circle id="imu-bubble" cx="50" cy="50" r="9"
+                  fill="#4fc3f7" fill-opacity="0.65" stroke="#81d4fa" stroke-width="1.5"/>
+          <text x="90" y="53" fill="#445" font-size="8" font-family="system-ui">X</text>
+          <text x="44" y="9"  fill="#445" font-size="8" font-family="system-ui">Y</text>
+        </svg>
       </article>
 
       <!-- Motor Driver -->
@@ -476,6 +528,117 @@ pub fn dashboard_html() -> &'static str {
             <div class="name">Right</div>
             <div class="val" id="motor-right">--</div>
           </div>
+        </div>
+      </article>
+
+      <!-- Hardware Simulation -->
+      <article class="panel card span-12">
+        <h2>Hardware Simulation</h2>
+        <div class="hw-sim-grid">
+
+          <!-- LED -->
+          <div class="hw-item">
+            <div class="hw-name">&#x1F4A1; LED</div>
+            <svg id="led-svg" viewBox="0 0 80 100" width="80" height="100">
+              <defs>
+                <radialGradient id="led-gon" cx="38%" cy="35%" r="60%">
+                  <stop offset="0%" stop-color="#fff8a0"/>
+                  <stop offset="100%" stop-color="#ffcc00"/>
+                </radialGradient>
+                <radialGradient id="led-goff" cx="38%" cy="35%" r="60%">
+                  <stop offset="0%" stop-color="#4a3a10"/>
+                  <stop offset="100%" stop-color="#1a1200"/>
+                </radialGradient>
+                <filter id="led-glow" x="-100%" y="-100%" width="300%" height="300%">
+                  <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur"/>
+                  <feMerge>
+                    <feMergeNode in="blur"/>
+                    <feMergeNode in="blur"/>
+                    <feMergeNode in="SourceGraphic"/>
+                  </feMerge>
+                </filter>
+              </defs>
+              <circle id="led-body" cx="40" cy="40" r="24"
+                      fill="url(#led-goff)" stroke="#666" stroke-width="1.5"/>
+              <ellipse id="led-hl" cx="34" cy="32" rx="7" ry="5"
+                       fill="white" fill-opacity="0"/>
+              <line x1="32" y1="64" x2="32" y2="80"
+                    stroke="#888" stroke-width="2.5" stroke-linecap="round"/>
+              <line x1="48" y1="64" x2="48" y2="80"
+                    stroke="#888" stroke-width="2.5" stroke-linecap="round"/>
+              <text x="27" y="92" fill="#666" font-size="11" font-family="monospace">+</text>
+              <text x="44" y="92" fill="#666" font-size="11" font-family="monospace">&#x2212;</text>
+              <text id="led-lbl" x="40" y="100" text-anchor="middle"
+                    fill="#666" font-size="9" font-family="system-ui">OFF</text>
+            </svg>
+          </div>
+
+          <!-- Servo -->
+          <div class="hw-item">
+            <div class="hw-name">&#x2699; Servo</div>
+            <svg id="servo-svg" viewBox="0 0 120 114" width="120" height="114">
+              <rect x="20" y="62" width="80" height="42" rx="6" fill="#1e2a3a" stroke="#445"/>
+              <rect x="9"  y="68" width="14" height="28" rx="3" fill="#1e2a3a" stroke="#445"/>
+              <rect x="97" y="68" width="14" height="28" rx="3" fill="#1e2a3a" stroke="#445"/>
+              <circle cx="16"  cy="82" r="3" fill="none" stroke="#445"/>
+              <circle cx="104" cy="82" r="3" fill="none" stroke="#445"/>
+              <circle cx="60"  cy="62" r="10" fill="#2e3d4d" stroke="#556"/>
+              <circle cx="60"  cy="62" r="4"  fill="#607890"/>
+              <!-- Arm rotates around shaft pivot (60, 62) -->
+              <g id="servo-arm" transform="rotate(0 60 62)">
+                <rect x="57.5" y="16" width="5" height="46" rx="2.5" fill="#4fc3f7"/>
+                <circle cx="60" cy="16" r="5.5" fill="#4fc3f7"/>
+                <circle cx="60" cy="62" r="3.5" fill="#81d4fa"/>
+              </g>
+              <text id="servo-lbl" x="60" y="112" text-anchor="middle"
+                    fill="#888" font-size="11" font-family="system-ui">90&#xB0;</text>
+            </svg>
+          </div>
+
+          <!-- Motor Left -->
+          <div class="hw-item">
+            <div class="hw-name">&#x1F504; Motor L</div>
+            <svg viewBox="0 0 90 104" width="90" height="104">
+              <circle cx="45" cy="45" r="36" fill="#111820" stroke="#334" stroke-width="1.5"/>
+              <g id="m-left-rotor">
+                <line x1="45" y1="16" x2="45" y2="74" stroke="#2a4a2a" stroke-width="2"/>
+                <line x1="16" y1="45" x2="74" y2="45" stroke="#2a4a2a" stroke-width="2"/>
+                <circle cx="45" cy="16" r="4.5" fill="#66bb6a"/>
+                <circle cx="74" cy="45" r="4.5" fill="#66bb6a"/>
+                <circle cx="45" cy="74" r="4.5" fill="#66bb6a"/>
+                <circle cx="16" cy="45" r="4.5" fill="#66bb6a"/>
+              </g>
+              <circle cx="45" cy="45" r="7"   fill="#334" stroke="#556"/>
+              <circle cx="45" cy="45" r="3"   fill="#778"/>
+              <rect x="9"  y="88" width="72" height="6" rx="3" fill="#1a2020"/>
+              <rect id="m-left-bar" x="9" y="88" width="0" height="6" rx="3" fill="#66bb6a"/>
+              <text id="m-left-lbl" x="45" y="103" text-anchor="middle"
+                    fill="#888" font-size="9" font-family="system-ui">--</text>
+            </svg>
+          </div>
+
+          <!-- Motor Right -->
+          <div class="hw-item">
+            <div class="hw-name">&#x1F504; Motor R</div>
+            <svg viewBox="0 0 90 104" width="90" height="104">
+              <circle cx="45" cy="45" r="36" fill="#111820" stroke="#334" stroke-width="1.5"/>
+              <g id="m-right-rotor">
+                <line x1="45" y1="16" x2="45" y2="74" stroke="#2a4a2a" stroke-width="2"/>
+                <line x1="16" y1="45" x2="74" y2="45" stroke="#2a4a2a" stroke-width="2"/>
+                <circle cx="45" cy="16" r="4.5" fill="#66bb6a"/>
+                <circle cx="74" cy="45" r="4.5" fill="#66bb6a"/>
+                <circle cx="45" cy="74" r="4.5" fill="#66bb6a"/>
+                <circle cx="16" cy="45" r="4.5" fill="#66bb6a"/>
+              </g>
+              <circle cx="45" cy="45" r="7"   fill="#334" stroke="#556"/>
+              <circle cx="45" cy="45" r="3"   fill="#778"/>
+              <rect x="9"  y="88" width="72" height="6" rx="3" fill="#1a2020"/>
+              <rect id="m-right-bar" x="9" y="88" width="0" height="6" rx="3" fill="#66bb6a"/>
+              <text id="m-right-lbl" x="45" y="103" text-anchor="middle"
+                    fill="#888" font-size="9" font-family="system-ui">--</text>
+            </svg>
+          </div>
+
         </div>
       </article>
 
@@ -542,6 +705,96 @@ pub fn dashboard_html() -> &'static str {
     const fmt = (v, sfx) => v == null ? "--" : v + sfx;
     const lcdLines = ["lcd-line-1","lcd-line-2"].map(id => $(id));
 
+    // ── Motor animation (requestAnimationFrame loop) ──
+    const mAngle = { left: 0, right: 0 };
+    const mState = {
+      left:  { run: false, spd: 0, dir: 1 },
+      right: { run: false, spd: 0, dir: 1 }
+    };
+    (function motorLoop() {
+      for (const side of ["left", "right"]) {
+        if (!mState[side].run) continue;
+        mAngle[side] = (mAngle[side] + mState[side].spd * mState[side].dir + 360) % 360;
+        const r = $("m-" + side + "-rotor");
+        if (r) r.setAttribute("transform",
+          "rotate(" + mAngle[side].toFixed(1) + " 45 45)");
+      }
+      requestAnimationFrame(motorLoop);
+    })();
+
+    // ── LED ──
+    function setLed(tick) {
+      const on = (tick % 100) < 50;
+      const body = $("led-body");
+      if (!body) return;
+      body.setAttribute("fill", on ? "url(#led-gon)" : "url(#led-goff)");
+      body.setAttribute("filter", on ? "url(#led-glow)" : "");
+      const hl = $("led-hl");
+      if (hl) hl.setAttribute("fill-opacity", on ? "0.38" : "0");
+      const lbl = $("led-lbl");
+      if (lbl) {
+        lbl.textContent = on ? "ON" : "OFF";
+        lbl.setAttribute("fill", on ? "#ffdd44" : "#666");
+      }
+    }
+
+    // ── Servo ──
+    function setServo(angleDeg) {
+      const arm = $("servo-arm");
+      if (arm) arm.setAttribute("transform",
+        "rotate(" + (angleDeg - 90) + " 60 62)");
+      const lbl = $("servo-lbl");
+      if (lbl) lbl.textContent = angleDeg + "\u00B0";
+    }
+
+    // ── Motor visual ──
+    function setMotorViz(side, dir, duty) {
+      const stopped = dir === "Brake" || dir === "Coast" || duty < 3;
+      mState[side].run = !stopped;
+      mState[side].spd = stopped ? 0 : (2 + duty * 0.1);
+      mState[side].dir = dir === "Reverse" ? -1 : 1;
+      const bar = $("m-" + side + "-bar");
+      if (bar) bar.setAttribute("width", String(Math.round(duty * 72 / 100)));
+      const lbl = $("m-" + side + "-lbl");
+      if (lbl) {
+        const icon = stopped
+          ? (dir === "Brake" ? "\u25A0" : "\u2014")
+          : (dir === "Reverse" ? "\u21BA" : "\u21BB");
+        lbl.textContent = icon + " " + (stopped ? dir : duty + "%");
+      }
+    }
+
+    // ── Sonar ──
+    function setSonar(distMm) {
+      const MAX = 600, X0 = 35, X1 = 188;
+      const d = distMm == null ? 300 : distMm;
+      const x = (X0 + (Math.min(d, MAX) / MAX) * (X1 - X0)).toFixed(0);
+      const beam = $("sonar-beam");
+      const echo = $("sonar-echo");
+      const txt  = $("sonar-dist-lbl");
+      if (beam) beam.setAttribute("x2", x);
+      if (echo) {
+        echo.setAttribute("cx", x);
+        echo.setAttribute("fill",
+          d < 200 ? "#ef5350" : d < 400 ? "#ffca28" : "#66bb6a");
+      }
+      if (txt) txt.textContent = distMm == null ? "-- mm" : distMm + " mm";
+    }
+
+    // ── IMU bubble level ──
+    function setImuLevel(ax, ay) {
+      const bubble = $("imu-bubble");
+      if (!bubble) return;
+      const s = 30 / 1000;
+      const bx = Math.max(14, Math.min(86, 50 + ax * s)).toFixed(1);
+      const by = Math.max(14, Math.min(86, 50 - ay * s)).toFixed(1);
+      bubble.setAttribute("cx", bx);
+      bubble.setAttribute("cy", by);
+      const tilt = Math.sqrt(ax * ax + ay * ay);
+      bubble.setAttribute("fill",
+        tilt > 700 ? "#ef5350" : tilt > 300 ? "#ffca28" : "#4fc3f7");
+    }
+
     // ── Main refresh ──
     let paused = false;
     async function refresh() {
@@ -598,6 +851,14 @@ pub fn dashboard_html() -> &'static str {
         sparkline("spark-press",  hist.press);
         sparkline("spark-dist",   hist.dist);
         sparkline("spark-accelz", hist.accelz);
+
+        // visual simulation
+        setLed(s.tick);
+        setServo(s.servo.angle_degrees);
+        setMotorViz("left",  s.motor_driver.left.direction,  s.motor_driver.left.duty_percent);
+        setMotorViz("right", s.motor_driver.right.direction, s.motor_driver.right.duty_percent);
+        setSonar(s.distance.distance_mm);
+        setImuLevel(s.imu.accel_mg[0], s.imu.accel_mg[1]);
 
         setOk();
       } catch(e) {
@@ -672,6 +933,29 @@ mod tests {
         // status bar
         assert!(html.contains("sdot"));
         assert!(html.contains("stext"));
+    }
+
+    #[test]
+    fn html_contains_visual_simulation() {
+        let html = dashboard_html();
+        // LED
+        assert!(html.contains("led-body"));
+        assert!(html.contains("led-glow"));
+        assert!(html.contains("setLed"));
+        // Servo
+        assert!(html.contains("servo-arm"));
+        assert!(html.contains("setServo"));
+        // Motors
+        assert!(html.contains("m-left-rotor"));
+        assert!(html.contains("m-right-rotor"));
+        assert!(html.contains("setMotorViz"));
+        // Sonar
+        assert!(html.contains("sonar-beam"));
+        assert!(html.contains("sonar-echo"));
+        assert!(html.contains("setSonar"));
+        // IMU bubble level
+        assert!(html.contains("imu-bubble"));
+        assert!(html.contains("setImuLevel"));
     }
 
     #[test]

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -643,13 +643,16 @@ pub fn dashboard_html() -> &'static str {
       </article>
 
       <!-- Wiring -->
-      <article class="panel card span-4">
-        <h2>Wiring</h2>
-        <div class="wiring" id="wiring-view"></div>
+      <article class="panel card span-8">
+        <h2>Wiring Diagram</h2>
+        <div id="wiring-svg-wrap" style="width:100%;overflow-x:auto;min-height:180px"></div>
+        <div class="footer" style="margin-top:6px">
+          Attached: <span id="wiring-devices" style="font-family:monospace">--</span>
+        </div>
       </article>
 
       <!-- I2C Activity -->
-      <article class="panel card span-8">
+      <article class="panel card span-4">
         <h2>I2C Activity</h2>
         <ul class="ops" id="i2c-ops"></ul>
       </article>
@@ -795,6 +798,19 @@ pub fn dashboard_html() -> &'static str {
         tilt > 700 ? "#ef5350" : tilt > 300 ? "#ffca28" : "#4fc3f7");
     }
 
+    // ── Wiring diagram (loaded once at startup, then refreshed every 5s) ──
+    async function loadWiringDiagram() {
+      try {
+        const r = await fetch("/api/wiring/svg");
+        if (!r.ok) return;
+        const svg = await r.text();
+        const wrap = $("wiring-svg-wrap");
+        if (wrap) wrap.innerHTML = svg;
+      } catch(_) {}
+    }
+    loadWiringDiagram();
+    setInterval(loadWiringDiagram, 5000);
+
     // ── Main refresh ──
     let paused = false;
     async function refresh() {
@@ -830,7 +846,8 @@ pub fn dashboard_html() -> &'static str {
         $("motor-left").textContent  = s.motor_driver.left.direction  + " " + s.motor_driver.left.duty_percent  + "%";
         $("motor-right").textContent = s.motor_driver.right.direction + " " + s.motor_driver.right.duty_percent + "%";
 
-        $("wiring-view").textContent = s.wiring.diagram_lines.join("\n");
+        const devEl = $("wiring-devices");
+        if (devEl) devEl.textContent = s.wiring.attached_devices.join(", ") || "--";
 
         const ops = $("i2c-ops");
         ops.innerHTML = "";
@@ -933,6 +950,10 @@ mod tests {
         // status bar
         assert!(html.contains("sdot"));
         assert!(html.contains("stext"));
+        // wiring SVG diagram
+        assert!(html.contains("/api/wiring/svg"));
+        assert!(html.contains("wiring-svg-wrap"));
+        assert!(html.contains("loadWiringDiagram"));
     }
 
     #[test]

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -153,6 +153,9 @@ fn json_string(value: &str) -> String {
             '\n' => output.push_str("\\n"),
             '\r' => output.push_str("\\r"),
             '\t' => output.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                output.push_str(&format!("\\u{:04X}", c as u32));
+            }
             _ => output.push(character),
         }
     }
@@ -778,17 +781,17 @@ pub fn dashboard_html() -> &'static str {
 
     // ── Motor visual ──
     function setMotorViz(side, dir, duty) {
-      const stopped = dir === "Brake" || dir === "Coast" || duty < 3;
+      const stopped = dir === "brake" || dir === "coast" || duty < 3;
       mState[side].run = !stopped;
       mState[side].spd = stopped ? 0 : (2 + duty * 0.1);
-      mState[side].dir = dir === "Reverse" ? -1 : 1;
+      mState[side].dir = dir === "reverse" ? -1 : 1;
       const bar = $("m-" + side + "-bar");
       if (bar) bar.setAttribute("width", String(Math.round(duty * 72 / 100)));
       const lbl = $("m-" + side + "-lbl");
       if (lbl) {
         const icon = stopped
-          ? (dir === "Brake" ? "\u25A0" : "\u2014")
-          : (dir === "Reverse" ? "\u21BA" : "\u21BB");
+          ? (dir === "brake" ? "\u25A0" : "\u2014")
+          : (dir === "reverse" ? "\u21BA" : "\u21BB");
         lbl.textContent = icon + " " + (stopped ? dir : duty + "%");
       }
     }

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -341,6 +341,25 @@ pub fn dashboard_html() -> &'static str {
     }
     /* ── Footer ── */
     .footer { margin-top: 18px; color: var(--muted); font-size: 13px; }
+    /* ── E2E Test Runner ── */
+    .test-run-btn {
+      font-family: inherit; font-size: 13px;
+      border: 1px solid var(--line); border-radius: 8px;
+      padding: 6px 14px; background: rgba(15,124,107,0.1); color: var(--ink);
+      cursor: pointer; transition: background 0.2s; margin-bottom: 10px;
+    }
+    .test-run-btn:hover  { background: rgba(15,124,107,0.22); }
+    .test-run-btn:disabled { opacity: 0.45; cursor: default; }
+    #test-output {
+      background: #0d1117; color: #c9d1d9;
+      font-family: "IBM Plex Mono","Menlo",monospace; font-size: 0.73rem;
+      height: 220px; overflow-y: auto; padding: 8px 10px;
+      border-radius: 10px; border: 1px solid var(--line);
+    }
+    #test-output .tpass { color: #4caf50; }
+    #test-output .tfail { color: #f44336; }
+    #test-output .twarn { color: #ffa726; }
+    #test-output .tdone { color: #7e57c2; font-weight: bold; }
     /* ── Responsive ── */
     @media (max-width: 980px) {
       .hero,.grid { grid-template-columns: 1fr; }
@@ -657,6 +676,13 @@ pub fn dashboard_html() -> &'static str {
         <ul class="ops" id="i2c-ops"></ul>
       </article>
 
+      <!-- E2E Test Runner -->
+      <article class="panel card span-12">
+        <h2>&#x1F9EA; E2E Test Runner</h2>
+        <button class="test-run-btn" id="run-tests-btn" onclick="runTests()">&#x25B6; Run Tests (cargo test --workspace)</button>
+        <div id="test-output"></div>
+      </article>
+
     </section>
   </main>
 
@@ -883,6 +909,54 @@ pub fn dashboard_html() -> &'static str {
       }
     }
 
+    // ── E2E Test Runner ──
+    function runTests() {
+      const out = $("test-output");
+      out.innerHTML = "";
+      const btn = $("run-tests-btn");
+      btn.disabled = true;
+      btn.textContent = "Running\u2026";
+
+      const addLine = (text, cls) => {
+        const div = document.createElement("div");
+        div.textContent = text;
+        if (cls) div.className = cls;
+        out.appendChild(div);
+        out.scrollTop = out.scrollHeight;
+      };
+
+      const es = new EventSource("/api/test/stream");
+      es.onmessage = (e) => {
+        const line = e.data;
+        if (line.startsWith("[DONE]")) {
+          es.close();
+          btn.disabled = false;
+          btn.textContent = "\u25B6 Run Tests (cargo test --workspace)";
+          const ok = line.includes("exit=0");
+          addLine(ok ? "\u2714 All tests passed" : "\u2718 Tests finished with failures", ok ? "tpass" : "tfail");
+          addLine(line, "tdone");
+          return;
+        }
+        if (line.startsWith("[ERROR]")) { addLine(line, "tfail"); return; }
+        const lower = line.toLowerCase();
+        if (/\bFAILED\b/.test(line) || /^error/.test(lower)) {
+          addLine(line, "tfail");
+        } else if (/\.\.\. ok$/.test(line) || /^test result: ok/.test(lower)) {
+          addLine(line, "tpass");
+        } else if (/^warning/.test(lower)) {
+          addLine(line, "twarn");
+        } else {
+          addLine(line, "");
+        }
+      };
+      es.onerror = () => {
+        es.close();
+        btn.disabled = false;
+        btn.textContent = "\u25B6 Run Tests (cargo test --workspace)";
+        addLine("[ERROR] connection lost", "tfail");
+      };
+    }
+
     // ── Interval control ──
     let timerId = null;
     function startTimer(ms) {
@@ -954,6 +1028,11 @@ mod tests {
         assert!(html.contains("/api/wiring/svg"));
         assert!(html.contains("wiring-svg-wrap"));
         assert!(html.contains("loadWiringDiagram"));
+        // E2E test runner
+        assert!(html.contains("/api/test/stream"));
+        assert!(html.contains("run-tests-btn"));
+        assert!(html.contains("runTests"));
+        assert!(html.contains("test-output"));
     }
 
     #[test]

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -84,6 +84,11 @@ pub struct WiringConfig {
 
 impl WiringConfig {
     /// Build the standard wiring config for a board profile.
+    ///
+    /// Returns a fixed simulator configuration: BME280 (0x77), MPU6050 (0x68),
+    /// LCD1602 (0x27) on I²C, and HC-SR04 on GPIO.  All four devices are always
+    /// present regardless of the profile; this matches the `DeviceSimulationRig`
+    /// setup used by the PC simulator.
     pub fn from_board(board: BoardProfile) -> Self {
         let devices = vec![
             DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
@@ -123,9 +128,9 @@ impl WiringConfig {
                 match d.address {
                     Some(a) => format!(
                         r#"{{"kind":"{kind}","address":"0x{a:02X}","label":"{}"}}"#,
-                        d.label
+                        json_escape(&d.label)
                     ),
-                    None => format!(r#"{{"kind":"{kind}","label":"{}"}}"#, d.label),
+                    None => format!(r#"{{"kind":"{kind}","label":"{}"}}"#, json_escape(&d.label)),
                 }
             })
             .collect();
@@ -137,16 +142,35 @@ impl WiringConfig {
                 r#""devices":[{devs}]}}"#
             ),
             board = board_str,
-            sda = self.sda_pin,
-            scl = self.scl_pin,
-            vcc = self.power_pin,
-            gnd = self.ground_pin,
-            trig = self.trig_pin,
-            echo = self.echo_pin,
-            sv = self.servo_pin,
+            sda = json_escape(&self.sda_pin),
+            scl = json_escape(&self.scl_pin),
+            vcc = json_escape(&self.power_pin),
+            gnd = json_escape(&self.ground_pin),
+            trig = json_escape(&self.trig_pin),
+            echo = json_escape(&self.echo_pin),
+            sv = json_escape(&self.servo_pin),
             devs = devices.join(","),
         )
     }
+}
+
+/// Escape a string for embedding in a JSON value (no surrounding quotes added).
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -169,6 +193,9 @@ mod tests {
         assert_eq!(cfg.sda_pin, "A4");
         assert_eq!(cfg.scl_pin, "A5");
         assert_eq!(cfg.power_pin, "5V");
+        assert_eq!(cfg.trig_pin, "D2");
+        assert_eq!(cfg.echo_pin, "D3");
+        assert_eq!(cfg.servo_pin, "D9");
     }
 
     #[test]

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -1,0 +1,191 @@
+//! Wiring configuration: which devices are connected to which board pins.
+//!
+//! Provides a board-independent description of the hardware setup used by
+//! the visual wiring diagram generator.
+
+use crate::dashboard::BoardProfile;
+
+/// Physical device type attached to the board.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeviceKind {
+    Bme280,
+    Mpu6050,
+    Lcd1602,
+    HcSr04,
+}
+
+impl DeviceKind {
+    pub fn label(&self) -> &str {
+        match self {
+            DeviceKind::Bme280 => "BME280",
+            DeviceKind::Mpu6050 => "MPU6050",
+            DeviceKind::Lcd1602 => "LCD1602",
+            DeviceKind::HcSr04 => "HC-SR04",
+        }
+    }
+
+    pub fn connection_type(&self) -> ConnectionType {
+        match self {
+            DeviceKind::HcSr04 => ConnectionType::Gpio,
+            _ => ConnectionType::I2c,
+        }
+    }
+}
+
+/// How a device is connected to the board.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConnectionType {
+    I2c,
+    Gpio,
+}
+
+/// Specification of a single device in the wiring config.
+#[derive(Debug, Clone)]
+pub struct DeviceSpec {
+    pub kind: DeviceKind,
+    /// I2C address (None for GPIO devices).
+    pub address: Option<u8>,
+    pub label: String,
+}
+
+impl DeviceSpec {
+    pub fn i2c(kind: DeviceKind, address: u8) -> Self {
+        let label = format!("{} (0x{address:02X})", kind.label());
+        Self {
+            kind,
+            address: Some(address),
+            label,
+        }
+    }
+
+    pub fn gpio(kind: DeviceKind) -> Self {
+        let label = kind.label().to_string();
+        Self {
+            kind,
+            address: None,
+            label,
+        }
+    }
+}
+
+/// Full wiring description for the board + all attached devices.
+#[derive(Debug, Clone)]
+pub struct WiringConfig {
+    pub board: BoardProfile,
+    pub sda_pin: String,
+    pub scl_pin: String,
+    pub power_pin: String,
+    pub ground_pin: String,
+    pub trig_pin: String,
+    pub echo_pin: String,
+    pub servo_pin: String,
+    pub devices: Vec<DeviceSpec>,
+}
+
+impl WiringConfig {
+    /// Build the standard wiring config for a board profile.
+    pub fn from_board(board: BoardProfile) -> Self {
+        let devices = vec![
+            DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
+            DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
+            DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
+            DeviceSpec::gpio(DeviceKind::HcSr04),
+        ];
+        Self {
+            sda_pin: board.sda_pin().to_string(),
+            scl_pin: board.scl_pin().to_string(),
+            power_pin: board.power_pin().to_string(),
+            ground_pin: "GND".to_string(),
+            trig_pin: board.trig_pin().to_string(),
+            echo_pin: board.echo_pin().to_string(),
+            servo_pin: board.servo_pwm_pin().to_string(),
+            board,
+            devices,
+        }
+    }
+
+    /// Serialise to a simple JSON string.
+    pub fn to_json(&self) -> String {
+        let board_str = match self.board {
+            BoardProfile::OriginalEsp32 => "esp32",
+            BoardProfile::ArduinoNano => "nano",
+        };
+        let devices: Vec<String> = self
+            .devices
+            .iter()
+            .map(|d| {
+                let kind = match d.kind {
+                    DeviceKind::Bme280 => "bme280",
+                    DeviceKind::Mpu6050 => "mpu6050",
+                    DeviceKind::Lcd1602 => "lcd1602",
+                    DeviceKind::HcSr04 => "hc_sr04",
+                };
+                match d.address {
+                    Some(a) => format!(
+                        r#"{{"kind":"{kind}","address":"0x{a:02X}","label":"{}"}}"#,
+                        d.label
+                    ),
+                    None => format!(r#"{{"kind":"{kind}","label":"{}"}}"#, d.label),
+                }
+            })
+            .collect();
+        format!(
+            concat!(
+                r#"{{"board":"{board}","sda_pin":"{sda}","scl_pin":"{scl}","#,
+                r#""power_pin":"{vcc}","ground_pin":"{gnd}","#,
+                r#""trig_pin":"{trig}","echo_pin":"{echo}","servo_pin":"{sv}","#,
+                r#""devices":[{devs}]}}"#
+            ),
+            board = board_str,
+            sda = self.sda_pin,
+            scl = self.scl_pin,
+            vcc = self.power_pin,
+            gnd = self.ground_pin,
+            trig = self.trig_pin,
+            echo = self.echo_pin,
+            sv = self.servo_pin,
+            devs = devices.join(","),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wiring_config_esp32_has_expected_pins() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        assert_eq!(cfg.sda_pin, "GPIO21");
+        assert_eq!(cfg.scl_pin, "GPIO22");
+        assert_eq!(cfg.power_pin, "3V3");
+        assert_eq!(cfg.trig_pin, "GPIO5");
+        assert_eq!(cfg.servo_pin, "GPIO13");
+    }
+
+    #[test]
+    fn wiring_config_nano_has_expected_pins() {
+        let cfg = WiringConfig::from_board(BoardProfile::ArduinoNano);
+        assert_eq!(cfg.sda_pin, "A4");
+        assert_eq!(cfg.scl_pin, "A5");
+        assert_eq!(cfg.power_pin, "5V");
+    }
+
+    #[test]
+    fn wiring_config_has_four_devices() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        assert_eq!(cfg.devices.len(), 4);
+        assert_eq!(cfg.devices[0].kind, DeviceKind::Bme280);
+        assert_eq!(cfg.devices[3].kind, DeviceKind::HcSr04);
+        assert_eq!(cfg.devices[3].kind.connection_type(), ConnectionType::Gpio);
+    }
+
+    #[test]
+    fn wiring_config_to_json_contains_board_and_devices() {
+        let json = WiringConfig::from_board(BoardProfile::OriginalEsp32).to_json();
+        assert!(json.contains(r#""board":"esp32""#));
+        assert!(json.contains(r#""sda_pin":"GPIO21""#));
+        assert!(json.contains(r#""address":"0x77""#));
+        assert!(json.contains(r#""kind":"hc_sr04""#));
+    }
+}

--- a/crates/platform-pc-sim/wiring_svg.rs
+++ b/crates/platform-pc-sim/wiring_svg.rs
@@ -1,0 +1,261 @@
+//! PCB-style animated wiring diagram SVG generator.
+//!
+//! Generates an inline SVG showing the board pins connected to attached
+//! devices with colour-coded Bezier wires and CSS stroke-dashoffset
+//! animations that simulate current flow on data lines.
+
+use std::fmt::Write as _;
+
+use crate::wiring_config::{ConnectionType, WiringConfig};
+
+/// Generate a self-contained SVG string for the given wiring config.
+pub fn wiring_svg(config: &WiringConfig) -> String {
+    let mut buf = String::with_capacity(8192);
+    render(&mut buf, config);
+    buf
+}
+
+// ── layout constants ────────────────────────────────────────────────────────
+const W: i32 = 560;
+const H: i32 = 380;
+
+const BOARD_X: i32 = 16;
+const BOARD_Y: i32 = 44;
+const BOARD_W: i32 = 104;
+const BOARD_H: i32 = 292;
+
+// Board right edge (where pin dots sit)
+const BOARD_R: i32 = BOARD_X + BOARD_W; // 120
+
+// Pin Y positions on the board right edge
+const P_SDA: i32 = BOARD_Y + 52;
+const P_SCL: i32 = BOARD_Y + 96;
+const P_VCC: i32 = BOARD_Y + 152;
+const P_GND: i32 = BOARD_Y + 200;
+
+// Devices
+const DEV_X: i32 = 382;
+const DEV_W: i32 = 148;
+const DEV_H: i32 = 52;
+const DEV_GAP: i32 = 14;
+
+#[allow(clippy::write_with_newline)]
+fn render(out: &mut String, config: &WiringConfig) {
+    // SVG open + styles
+    let _ = write!(
+        out,
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" style="width:100%;max-height:{H}px;background:#0c1a12;border-radius:8px;display:block">
+<defs><style>
+.pcb-board{{fill:#152e15;stroke:#3d7a3d;stroke-width:2}}
+.pcb-lbl{{fill:#7bc47b;font:bold 11px monospace}}
+.pcb-sub{{fill:#5a9a5a;font:9px monospace}}
+.pcb-pin{{fill:#9ab;font:10px monospace}}
+.dev-box{{fill:#1a2333;stroke:#3a5888;stroke-width:1.5}}
+.dev-lbl{{fill:#7ab0e8;font:bold 10px monospace}}
+.dev-sub{{fill:#6888aa;font:9px monospace}}
+.w-sda{{fill:none;stroke:#4488ff;stroke-width:2.2;stroke-dasharray:8 4;animation:wiring-flow 1.2s linear infinite}}
+.w-scl{{fill:none;stroke:#ffdd44;stroke-width:1.8;stroke-dasharray:8 4;animation:wiring-flow 1.7s linear infinite reverse}}
+.w-vcc{{fill:none;stroke:#e55;stroke-width:1.6}}
+.w-gnd{{fill:none;stroke:#556;stroke-width:1.6}}
+.w-gpio{{fill:none;stroke:#ff9944;stroke-width:1.8;stroke-dasharray:6 3;animation:wiring-flow 2s linear infinite}}
+@keyframes wiring-flow{{from{{stroke-dashoffset:24}}to{{stroke-dashoffset:0}}}}
+.dot-sda{{fill:#4488ff}}.dot-scl{{fill:#ffdd44}}.dot-vcc{{fill:#e55}}.dot-gnd{{fill:#556}}.dot-gpio{{fill:#ff9944}}
+.leg{{fill:#888;font:9px monospace}}
+</style></defs>
+"#
+    );
+
+    // Board PCB
+    let board_label = config.board.name();
+    let mcu_label = config.board.mcu();
+    let cx = BOARD_X + BOARD_W / 2;
+    let _ = write!(
+        out,
+        r#"<rect x="{BOARD_X}" y="{BOARD_Y}" width="{BOARD_W}" height="{BOARD_H}" rx="6" class="pcb-board"/>
+<text x="{cx}" y="{}" class="pcb-lbl" text-anchor="middle">{board_label}</text>
+<text x="{cx}" y="{}" class="pcb-sub" text-anchor="middle">{mcu_label}</text>
+"#,
+        BOARD_Y + 20,
+        BOARD_Y + 33,
+    );
+
+    // Board pin dots + labels
+    for (cy, dot_cls, label) in [
+        (P_SDA, "dot-sda", format!("SDA/{}", config.sda_pin)),
+        (P_SCL, "dot-scl", format!("SCL/{}", config.scl_pin)),
+        (P_VCC, "dot-vcc", config.power_pin.clone()),
+        (P_GND, "dot-gnd", config.ground_pin.clone()),
+    ] {
+        let _ = write!(
+            out,
+            r#"<circle cx="{BOARD_R}" cy="{cy}" r="4" class="{dot_cls}"/>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">{label}</text>
+"#,
+            BOARD_R - 7,
+            cy + 4,
+        );
+    }
+
+    // Additional GPIO pins label block
+    let gpio_y = BOARD_Y + 240;
+    let _ = write!(
+        out,
+        r#"<text x="{}" y="{}" class="pcb-sub" text-anchor="middle">GPIO</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">TRIG/{}</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">ECHO/{}</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">PWM/{}</text>
+"#,
+        cx,
+        gpio_y - 6,
+        BOARD_R - 7,
+        gpio_y + 8,
+        config.trig_pin,
+        BOARD_R - 7,
+        gpio_y + 22,
+        config.echo_pin,
+        BOARD_R - 7,
+        gpio_y + 36,
+        config.servo_pin,
+    );
+
+    // Devices
+    let n = config.devices.len().max(1);
+    let total_h = n as i32 * (DEV_H + DEV_GAP) - DEV_GAP;
+    let dev_start_y = BOARD_Y + (BOARD_H - total_h) / 2;
+
+    for (i, dev) in config.devices.iter().enumerate() {
+        let dy = dev_start_y + i as i32 * (DEV_H + DEV_GAP);
+        let mid_y = dy + DEV_H / 2;
+        let conn = dev.kind.connection_type();
+
+        // Control point x for Bezier curves (~60% of the way)
+        let cp = BOARD_R + (DEV_X - BOARD_R) * 6 / 10;
+
+        // Device box
+        let _ = write!(
+            out,
+            r#"<rect x="{DEV_X}" y="{dy}" width="{DEV_W}" height="{DEV_H}" rx="4" class="dev-box"/>
+<text x="{}" y="{}" class="dev-lbl">{}</text>
+"#,
+            DEV_X + 8,
+            dy + 17,
+            dev.kind.label(),
+        );
+        if let Some(addr) = dev.address {
+            let _ = write!(
+                out,
+                r#"<text x="{}" y="{}" class="dev-sub">I²C addr: 0x{addr:02X}</text>
+"#,
+                DEV_X + 8,
+                dy + 31,
+            );
+        }
+
+        // VCC wire
+        let y_vcc = dy + 9;
+        let _ = write!(
+            out,
+            r#"<path class="w-vcc" d="M {BOARD_R} {P_VCC} C {cp} {P_VCC} {cp} {y_vcc} {DEV_X} {y_vcc}"/>
+"#
+        );
+
+        // GND wire
+        let y_gnd = dy + DEV_H - 9;
+        let _ = write!(
+            out,
+            r#"<path class="w-gnd" d="M {BOARD_R} {P_GND} C {cp} {P_GND} {cp} {y_gnd} {DEV_X} {y_gnd}"/>
+"#
+        );
+
+        match conn {
+            ConnectionType::I2c => {
+                let y_sda = mid_y - 7;
+                let y_scl = mid_y + 5;
+                let _ = write!(
+                    out,
+                    r#"<path class="w-sda" d="M {BOARD_R} {P_SDA} C {cp} {P_SDA} {cp} {y_sda} {DEV_X} {y_sda}"/>
+<circle cx="{DEV_X}" cy="{y_sda}" r="3" class="dot-sda"/>
+<path class="w-scl" d="M {BOARD_R} {P_SCL} C {cp} {P_SCL} {cp} {y_scl} {DEV_X} {y_scl}"/>
+<circle cx="{DEV_X}" cy="{y_scl}" r="3" class="dot-scl"/>
+"#
+                );
+            }
+            ConnectionType::Gpio => {
+                // HC-SR04: show GPIO connection
+                let trig_pin = &config.trig_pin;
+                let echo_pin = &config.echo_pin;
+                let _ = write!(
+                    out,
+                    r#"<path class="w-gpio" d="M {BOARD_R} {P_GND} C {cp} {P_GND} {cp} {mid_y} {DEV_X} {mid_y}"/>
+<text x="{}" y="{}" class="dev-sub">TRIG:{trig_pin} / ECHO:{echo_pin}</text>
+"#,
+                    DEV_X + 8,
+                    dy + 44,
+                );
+            }
+        }
+    }
+
+    // Legend at bottom — use CSS classes to avoid "# in raw string
+    let leg_y = H - 10;
+    let _ = write!(
+        out,
+        r#"<text x="{}" y="{leg_y}" class="leg" text-anchor="middle"><tspan class="dot-sda">━━</tspan> SDA <tspan dx="8" class="dot-scl">━━</tspan> SCL <tspan dx="8" class="dot-vcc">━━</tspan> VCC <tspan dx="8" class="dot-gnd">━━</tspan> GND <tspan dx="8" class="dot-gpio">━━</tspan> GPIO</text>
+"#,
+        W / 2,
+    );
+
+    out.push_str("</svg>");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dashboard::BoardProfile;
+    use crate::wiring_config::WiringConfig;
+
+    #[test]
+    fn wiring_svg_contains_board_label() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        let svg = wiring_svg(&cfg);
+        assert!(svg.contains("original ESP32"), "missing board label");
+        assert!(svg.contains("ESP32"), "missing MCU label");
+    }
+
+    #[test]
+    fn wiring_svg_contains_device_labels() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        let svg = wiring_svg(&cfg);
+        assert!(svg.contains("BME280"));
+        assert!(svg.contains("MPU6050"));
+        assert!(svg.contains("LCD1602"));
+        assert!(svg.contains("HC-SR04"));
+    }
+
+    #[test]
+    fn wiring_svg_contains_pin_labels() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        let svg = wiring_svg(&cfg);
+        assert!(svg.contains("GPIO21"), "missing SDA pin");
+        assert!(svg.contains("GPIO22"), "missing SCL pin");
+        assert!(svg.contains("3V3"), "missing power pin");
+    }
+
+    #[test]
+    fn wiring_svg_contains_animation_css() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        let svg = wiring_svg(&cfg);
+        assert!(svg.contains("wiring-flow"), "missing CSS animation name");
+        assert!(svg.contains("stroke-dasharray"), "missing dash array");
+        assert!(svg.contains("w-sda"), "missing SDA wire class");
+        assert!(svg.contains("w-scl"), "missing SCL wire class");
+    }
+
+    #[test]
+    fn wiring_svg_is_valid_svg_element() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        let svg = wiring_svg(&cfg);
+        assert!(svg.starts_with("<svg "));
+        assert!(svg.ends_with("</svg>"));
+    }
+}

--- a/crates/platform-pc-sim/wiring_svg.rs
+++ b/crates/platform-pc-sim/wiring_svg.rs
@@ -32,6 +32,8 @@ const P_SDA: i32 = BOARD_Y + 52;
 const P_SCL: i32 = BOARD_Y + 96;
 const P_VCC: i32 = BOARD_Y + 152;
 const P_GND: i32 = BOARD_Y + 200;
+/// Midpoint between TRIG (gpio_y+8) and ECHO (gpio_y+22) label rows.
+const P_GPIO: i32 = BOARD_Y + 255;
 
 // Devices
 const DEV_X: i32 = 382;
@@ -85,6 +87,7 @@ fn render(out: &mut String, config: &WiringConfig) {
         (P_SCL, "dot-scl", format!("SCL/{}", config.scl_pin)),
         (P_VCC, "dot-vcc", config.power_pin.clone()),
         (P_GND, "dot-gnd", config.ground_pin.clone()),
+        (P_GPIO, "dot-gpio", format!("GPIO/{}", config.trig_pin)),
     ] {
         let _ = write!(
             out,
@@ -181,12 +184,13 @@ fn render(out: &mut String, config: &WiringConfig) {
                 );
             }
             ConnectionType::Gpio => {
-                // HC-SR04: show GPIO connection
+                // HC-SR04: wire from GPIO pin dot to device midpoint
                 let trig_pin = &config.trig_pin;
                 let echo_pin = &config.echo_pin;
                 let _ = write!(
                     out,
-                    r#"<path class="w-gpio" d="M {BOARD_R} {P_GND} C {cp} {P_GND} {cp} {mid_y} {DEV_X} {mid_y}"/>
+                    r#"<path class="w-gpio" d="M {BOARD_R} {P_GPIO} C {cp} {P_GPIO} {cp} {mid_y} {DEV_X} {mid_y}"/>
+<circle cx="{DEV_X}" cy="{mid_y}" r="3" class="dot-gpio"/>
 <text x="{}" y="{}" class="dev-sub">TRIG:{trig_pin} / ECHO:{echo_pin}</text>
 "#,
                     DEV_X + 8,


### PR DESCRIPTION
## 概要

`feat/visual-simulation` ブランチに、ビジュアルハードウェアシミュレータ (Phase 1) と PCB 風アニメーション配線ダイアグラム (Phase 2) を追加しました。

## Phase 1 — ビジュアルハードウェアシミュレータ

ブラウザ (`/api/state` JSONを使用) だけでサーバー変更なしに動作します。

| コンポーネント | 表示内容 |
|---|---|
| 💡 LED | tick に連動した発光アニメ (グロー filter) |
| ⚙ サーボアーム | `angle_degrees` に応じた SVG 回転アーム |
| 🔄 モータ L/R | 方向・duty に連動した rotor 回転 + duty バー |
| 📏 HC-SR04 | SMIL ソナー ping リング + ビーム |
| 🔄 IMU | `accel_mg` に連動した水準器バブル |

## Phase 2 — PCB 風アニメーション配線ダイアグラム

### 新規ファイル

- `wiring_config.rs` — `WiringConfig` データモデル。`BoardProfile→WiringConfig` 変換、`to_json()`、ユニットテスト 5 個
- `wiring_svg.rs` — PCB スタイル SVG ジェネレーター。CSS `stroke-dashoffset` アニメ (SDA:青、SCL:黄、VCC:赤、GND:灰、GPIO:橙)、ベジェ曲線

### 新規 REST エンドポイント

| エンドポイント | 説明 |
|---|---|
| `GET /api/wiring` | 現在のボード設定を JSON で返す |
| `GET /api/wiring/svg` | アニメーション付き配線 SVG を返す (`image/svg+xml`) |

### ダッシュボード変更

- Wiring パネルを `span-4` → `span-8` に拡大、配線 SVG を表示
- I2C Activity パネルを `span-8` → `span-4` に縮小
- `loadWiringDiagram()` JS 関数で 5 秒ごとに SVG を自動更新

## 検証方法

```bash
# ビルド・テスト
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings

# 実行して確認
cargo run -p device-dashboard-web
# http://127.0.0.1:7878 にアクセス
# - LED が tick に合わせて点滅
# - Servo アームがリアルタイムで動く
# - Motor が方向/速度に応じて回転
# - Wiring パネルに PCB 風 SVG が表示
# - GET /api/wiring/svg で直接 SVG を確認
```

## 残タスク (次 PR 予定)

- Phase 3-A: SSE テストランナー (`/api/test/stream`)
- Phase 3-B: E2E ブラウザパネル
