### PR TITLE
feat: reactive wiring flash on I2C activity

### DIFF
--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -840,6 +840,27 @@ pub fn dashboard_html() -> &'static str {
     loadWiringDiagram();
     setInterval(loadWiringDiagram, 5000);
 
+    // ── Reactive wiring flash: I2C activity → SDA/SCL glow ──
+    let lastI2cFirstOp = '';
+    function flashWires() {
+      const wrap = $("wiring-svg-wrap");
+      if (!wrap) return;
+      const wires = wrap.querySelectorAll('.w-sda, .w-scl');
+      if (!wires.length) return;
+      wires.forEach(el => {
+        el.style.transition = '';
+        el.style.filter = 'brightness(3) drop-shadow(0 0 4px white)';
+        el.style.strokeWidth = '4.5';
+      });
+      setTimeout(() => {
+        wires.forEach(el => {
+          el.style.transition = 'filter 0.4s ease-out, stroke-width 0.4s ease-out';
+          el.style.filter = '';
+          el.style.strokeWidth = '';
+        });
+      }, 180);
+    }
+
     // ── Main refresh ──
     let paused = false;
     async function refresh() {
@@ -905,6 +926,13 @@ pub fn dashboard_html() -> &'static str {
         setMotorViz("right", s.motor_driver.right.direction, s.motor_driver.right.duty_percent);
         setSonar(s.distance.distance_mm);
         setImuLevel(s.imu.accel_mg[0], s.imu.accel_mg[1]);
+
+        // flash SDA/SCL wires when a new I2C operation is detected
+        const curOp = s.i2c.recent_operations[0] || '';
+        if (curOp && curOp !== lastI2cFirstOp) {
+          flashWires();
+          lastI2cFirstOp = curOp;
+        }
 
         setOk();
       } catch(e) {


### PR DESCRIPTION
## 概要

I2C操作が発生するたびに、配線ダイアグラムのSDA/SCLワイヤーが一瞬光るリアクティブアニメーションを追加しました。

## 変更内容

- `web_dashboard.rs` に `flashWires()` 関数を追加
  - `#wiring-svg-wrap` 内の `.w-sda` / `.w-scl` SVGパスを検索
  - 180ms間だけ `brightness(3) drop-shadow` を適用し、400msかけてフェードアウト
- `refresh()` 内で `lastI2cFirstOp` を追跡し、最新操作が変化したとき `flashWires()` を呼ぶ

## 技術詳細

- SVGジェネレータ（`wiring_svg.rs`）の変更なし — 既存の `.w-sda` / `.w-scl` クラスをそのまま活用
- JS inline style + setTimeout によるシンプルな実装
- サーバー側変更なし（`/api/state` の `i2c.recent_operations` をそのまま使用）

## テスト方法

```bash
cargo test --workspace --all-targets
cargo run -p device-dashboard-web
# http://127.0.0.1:7878 を開く
# → 接続から数秒後に I2C 操作が来るたびに配線ダイアグラムの青/黄ラインが光る
```

## CI

- cargo test ✅
- cargo clippy ✅
