### PR TITLE
feat: POST /api/wiring board-switch endpoint with UI selector

### DIFF
--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -362,6 +362,17 @@ fn format_operation(operation: &VirtualI2cOperation) -> String {
     }
 }
 
+/// Extract the `"board"` string value from a minimal JSON object.
+///
+/// Handles `{"board":"arduino-nano"}` without pulling in a full JSON parser.
+fn parse_board_from_json(json: &str) -> Option<&str> {
+    let after_key = json.split("\"board\"").nth(1)?;
+    let after_colon = after_key.split(':').nth(1)?.trim_start();
+    let inner = after_colon.strip_prefix('"')?;
+    let end = inner.find('"')?;
+    Some(&inner[..end])
+}
+
 fn respond(stream: &mut TcpStream, status: &str, content_type: &str, body: &str) {
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -475,20 +486,23 @@ fn main() {
             continue;
         };
         let request = String::from_utf8_lossy(&request[..read_len]);
-        let path = request
-            .lines()
-            .next()
-            .and_then(|line| line.split_whitespace().nth(1))
-            .unwrap_or("/");
+        let first_line = request.lines().next().unwrap_or("GET / HTTP/1.1");
+        let mut parts = first_line.split_whitespace();
+        let method = parts.next().unwrap_or("GET");
+        let path = parts.next().unwrap_or("/");
+        let body = request
+            .find("\r\n\r\n")
+            .map(|pos| &request[pos + 4..])
+            .unwrap_or("");
 
-        match path {
-            "/" => respond(
+        match (method, path) {
+            (_, "/") => respond(
                 &mut stream,
                 "200 OK",
                 "text/html; charset=utf-8",
                 dashboard_html(),
             ),
-            "/api/state" => {
+            (_, "/api/state") => {
                 let payload = state_to_json(&rig.step());
                 respond(
                     &mut stream,
@@ -497,7 +511,12 @@ fn main() {
                     &payload,
                 );
             }
-            "/api/wiring" => {
+            ("POST", "/api/wiring") => {
+                if let Some(board_name) = parse_board_from_json(body) {
+                    let new_board = BoardProfile::from_arg(Some(board_name));
+                    rig = DeviceSimulationRig::new(new_board);
+                    println!("board changed to: {}", rig.board.name());
+                }
                 let payload = WiringConfig::from_board(rig.board).to_json();
                 respond(
                     &mut stream,
@@ -506,12 +525,21 @@ fn main() {
                     &payload,
                 );
             }
-            "/api/wiring/svg" => {
+            (_, "/api/wiring") => {
+                let payload = WiringConfig::from_board(rig.board).to_json();
+                respond(
+                    &mut stream,
+                    "200 OK",
+                    "application/json; charset=utf-8",
+                    &payload,
+                );
+            }
+            (_, "/api/wiring/svg") => {
                 let cfg = WiringConfig::from_board(rig.board);
                 let svg = wiring_svg(&cfg);
                 respond(&mut stream, "200 OK", "image/svg+xml; charset=utf-8", &svg);
             }
-            "/api/test/stream" => {
+            (_, "/api/test/stream") => {
                 handle_test_stream(&mut stream);
             }
             _ => respond(
@@ -560,5 +588,31 @@ mod tests {
         assert_eq!(left.direction, MotorDirection::Forward);
         assert_eq!(right.direction, MotorDirection::Forward);
         assert_eq!(left.duty_percent, right.duty_percent);
+    }
+
+    #[test]
+    fn parse_board_from_json_extracts_board_name() {
+        assert_eq!(
+            parse_board_from_json(r#"{"board":"arduino-nano"}"#),
+            Some("arduino-nano")
+        );
+    }
+
+    #[test]
+    fn parse_board_from_json_handles_esp32_value() {
+        assert_eq!(
+            parse_board_from_json(r#"{"board":"original-esp32"}"#),
+            Some("original-esp32")
+        );
+    }
+
+    #[test]
+    fn parse_board_from_json_returns_none_for_missing_key() {
+        assert_eq!(parse_board_from_json(r#"{"other":"value"}"#), None);
+    }
+
+    #[test]
+    fn parse_board_from_json_returns_none_for_empty_body() {
+        assert_eq!(parse_board_from_json(""), None);
     }
 }

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -666,7 +666,13 @@ pub fn dashboard_html() -> &'static str {
 
       <!-- Wiring -->
       <article class="panel card span-8">
-        <h2>Wiring Diagram</h2>
+        <h2 style="display:flex;align-items:center;gap:12px">
+          Wiring Diagram
+          <select id="board-select" style="font-size:12px;background:#1a2a1a;color:#7bc47b;border:1px solid #3d7a3d;border-radius:4px;padding:2px 6px;cursor:pointer">
+            <option value="original-esp32">Original ESP32</option>
+            <option value="arduino-nano">Arduino Nano</option>
+          </select>
+        </h2>
         <div id="wiring-svg-wrap" style="width:100%;overflow-x:auto;min-height:180px"></div>
         <div class="footer" style="margin-top:6px">
           Attached: <span id="wiring-devices" style="font-family:monospace">--</span>
@@ -837,6 +843,18 @@ pub fn dashboard_html() -> &'static str {
         if (wrap) wrap.innerHTML = svg;
       } catch(_) {}
     }
+    async function changeBoard(boardName) {
+      try {
+        await fetch("/api/wiring", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ board: boardName }),
+        });
+        await loadWiringDiagram();
+      } catch(_) {}
+    }
+    const boardSel = $("board-select");
+    if (boardSel) boardSel.addEventListener("change", () => changeBoard(boardSel.value));
     loadWiringDiagram();
     setInterval(loadWiringDiagram, 5000);
 


### PR DESCRIPTION
## 概要

Wiring ダイアグラムのボードプロファイルを UI から切り替えられるようにしました。

## 変更内容

### サーバー側 (`device_dashboard_web.rs`)
- HTTPメソッドをリクエスト行からパース（GETとPOSTを区別）
- `parse_board_from_json()` ヘルパーを追加（最小JSONから `"board"` 値を抽出）
- `POST /api/wiring` ルートを追加：`{"board":"arduino-nano"}` などのJSONを受け取り、`DeviceSimulationRig` を新しいボードプロファイルで再初期化
- 既存の `GET /api/wiring`, `GET /api/wiring/svg` は影響なし

### UI側 (`web_dashboard.rs`)
- Wiring Diagramパネルのヘッダーに `<select>` を追加（Original ESP32 / Arduino Nano）
- `changeBoard()` JS関数を追加：POST後にSVGダイアグラムをリロード

### テスト
- `parse_board_from_json` の単体テストを4件追加（正常系・異常系）

## テスト方法

```bash
cargo test --workspace --all-targets
cargo run -p device-dashboard-web
# http://127.0.0.1:7878 を開く
# Wiring Diagramパネルのセレクターで「Arduino Nano」を選ぶ
# → SVGダイアグラムがArduino Nanoの配線に切り替わる
# → ターミナルに「board changed to: Arduino Nano」と表示される
```

## API仕様

```
POST /api/wiring
Content-Type: application/json

{"board":"arduino-nano"}

→ 200 OK (application/json)  — 新しいWiringConfigのJSON
```

有効なboard値: `"arduino-nano"`（それ以外はOriginal ESP32にフォールバック）
