### PR TITLE
chore: add reference-drivers to no_std CI and release v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Check core-app for no_std target
         run: cargo check -p core-app --lib --target $NO_STD_TARGET
 
+      - name: Check reference-drivers for no_std target
+        run: cargo check -p reference-drivers --lib --target $NO_STD_TARGET
+
       - name: Check platform-esp32 for no_std target
         run: cargo check -p platform-esp32 --lib --target $NO_STD_TARGET
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.1] - 2026-05-02
+
+v0.3.0 のビジュアルシミュレータに対するリアクティブアニメーション・ボード切替 API・ドキュメント整備を追加。CI の no_std チェック対象に `reference-drivers` を追加。
+
+### Added
+- **[#57]** I2C 操作が発生するたびに配線ダイアグラムの SDA/SCL ラインが白く光るリアクティブアニメーションを追加（`flashWires()` JS 関数、`recent_operations[0]` 変化検知）
+- **[#58]** `POST /api/wiring` エンドポイントを追加し、JSON ボディでボードプロファイルを切り替えられるようにした（`{"board":"arduino-nano"}`）
+- **[#58]** Wiring Diagram パネルのヘッダーにボードセレクター `<select>` を追加（Original ESP32 / Arduino Nano）
+- **[#59]** README の「実行」セクションをパネル別確認ポイント表と API curl 例を含む v0.3.0 対応に更新
+- CI `no_std Check` ジョブに `reference-drivers` の `thumbv6m-none-eabi` ビルド検証を追加
+
+### Fixed
+- **[#58]** HTTP メソッド（GET/POST）をリクエスト行からパースするよう修正し、GET と POST を正しく区別するようにした
+
+---
+
 ## [0.3.0] - 2026-05-02
 
 ブラウザダッシュボードにビジュアルハードウェアシミュレータ・PCB風アニメーション配線ダイアグラム・E2Eテストランナーを追加。


### PR DESCRIPTION
## 概要

2つの変更をまとめてリリース準備します。

## 変更内容

### 1. CI: reference-drivers を no_std Check に追加

`reference-drivers` は

追加した検証コマンド:
```
cargo check -p reference-drivers --lib --target thumbv6m-none-eabi
```

ローカルで通過確認済み。

### 2. CHANGELOG v0.3.1

PR #57, #58, #59 の変更をまとめて v0.3.1 として記録:
- reactive wiring flash（SDA/SCL 点滅）
- POST /api/wiring board-switch API + UI セレクター
- README v0.3.0 対応更新
- CI no_std Check 強化

## テスト方法

```bash
cargo test --workspace --all-targets
cargo check -p reference-drivers --lib --target thumbv6m-none-eabi
```
