### PR TITLE
feat: add servo/motor reference drivers backed by PwmOutput and GPIO traits

### DIFF
--- a/crates/hal-api/error.rs
+++ b/crates/hal-api/error.rs
@@ -120,3 +120,9 @@ pub enum ActuatorError {
     /// 通信または下位層のハードウェアエラー
     HardwareError,
 }
+
+impl From<GpioError> for ActuatorError {
+    fn from(_: GpioError) -> Self {
+        ActuatorError::HardwareError
+    }
+}

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -39,4 +39,5 @@ pub mod error;
 pub mod gpio;
 pub mod i2c;
 pub mod imu;
+pub mod pwm;
 pub mod sensor;

--- a/crates/hal-api/pwm.rs
+++ b/crates/hal-api/pwm.rs
@@ -1,0 +1,43 @@
+//! PWM output abstraction.
+
+/// PWM 出力ピンの抽象。
+///
+/// duty は 0–100 のパーセント単位。0 で常に LOW、100 で常に HIGH。
+///
+/// # Examples
+///
+/// ```
+/// use hal_api::pwm::PwmOutput;
+/// use hal_api::error::ActuatorError;
+///
+/// struct FixedPwm;
+///
+/// impl PwmOutput for FixedPwm {
+///     type Error = ActuatorError;
+///
+///     fn set_duty_percent(&mut self, duty: u8) -> Result<(), Self::Error> {
+///         if duty > 100 {
+///             return Err(ActuatorError::InvalidCommand);
+///         }
+///         Ok(())
+///     }
+///
+///     fn duty_percent(&self) -> u8 { 0 }
+/// }
+///
+/// let mut pwm = FixedPwm;
+/// assert!(pwm.set_duty_percent(50).is_ok());
+/// assert_eq!(pwm.set_duty_percent(101), Err(ActuatorError::InvalidCommand));
+/// ```
+pub trait PwmOutput {
+    /// エラー型
+    type Error;
+
+    /// デューティ比を設定する（0–100 %）。
+    ///
+    /// 100 を超える値が渡された場合、実装は `Err(InvalidCommand)` を返すこと。
+    fn set_duty_percent(&mut self, duty: u8) -> Result<(), Self::Error>;
+
+    /// 現在のデューティ比を返す（0–100 %）。
+    fn duty_percent(&self) -> u8;
+}

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -9,11 +9,12 @@ use hal_api::actuator::{DualMotorDriver, MotorCommand, MotorDirection, ServoMoto
 use hal_api::distance::DistanceSensor;
 use hal_api::imu::ImuSensor;
 use platform_pc_sim::bme280_mock::{demo_raw_samples, MockBme280Device};
-use platform_pc_sim::component_sim::{MockDualMotorDriver, MockServoMotor};
 use platform_pc_sim::dashboard::BoardProfile;
 use platform_pc_sim::hc_sr04_mock::{demo_echo_pulses_us, MockHcSr04Device};
 use platform_pc_sim::lcd1602_mock::MockLcd1602Device;
+use platform_pc_sim::mock_hal::MockPin;
 use platform_pc_sim::mpu6050_mock::{demo_raw_frames, MockMpu6050Device};
+use platform_pc_sim::pwm_mock::MockPwmOutput;
 use platform_pc_sim::virtual_i2c::{VirtualI2cBus, VirtualI2cOperation};
 use platform_pc_sim::web_dashboard::{
     dashboard_html, state_to_json, ClimatePanelState, DeviceDashboardState, DistancePanelState,
@@ -24,8 +25,10 @@ use platform_pc_sim::wiring_config::WiringConfig;
 use platform_pc_sim::wiring_svg::wiring_svg;
 use reference_drivers::bme280::{Bme280Sensor, BME280_ADDRESS_PRIMARY};
 use reference_drivers::hc_sr04::HcSr04Sensor;
+use reference_drivers::l298n::{L298nChannel, L298nDualDriver};
 use reference_drivers::lcd1602::{Lcd1602Display, LCD1602_ADDRESS_PRIMARY};
 use reference_drivers::mpu6050::{Mpu6050Sensor, MPU6050_ADDRESS_PRIMARY};
+use reference_drivers::servo::ServoDriver;
 
 const DEFAULT_PORT: u16 = 7878;
 
@@ -37,6 +40,10 @@ impl DelayNs for NoopDelay {
     fn delay_us(&mut self, _us: u32) {}
     fn delay_ms(&mut self, _ms: u32) {}
 }
+
+type ServoRig = ServoDriver<MockPwmOutput>;
+type MotorChannelRig = L298nChannel<MockPin, MockPin, MockPwmOutput>;
+type MotorDriverRig = L298nDualDriver<MotorChannelRig, MotorChannelRig>;
 
 struct DeviceSimulationRig {
     board: BoardProfile,
@@ -51,8 +58,8 @@ struct DeviceSimulationRig {
     imu_sensor: Mpu6050Sensor<VirtualI2cBus>,
     imu_frames: Vec<[u8; 14]>,
     imu_frame_index: usize,
-    servo: MockServoMotor,
-    motor_driver: MockDualMotorDriver,
+    servo: ServoRig,
+    motor_driver: MotorDriverRig,
     last_distance_mm: Option<u32>,
     last_imu: Option<hal_api::imu::ImuReading>,
 }
@@ -78,6 +85,12 @@ impl DeviceSimulationRig {
         let distance_sensor = HcSr04Sensor::new(MockHcSr04Device::looping(demo_echo_pulses_us()));
         let imu_sensor = Mpu6050Sensor::new(bus.clone());
 
+        let servo = ServoDriver::new(MockPwmOutput::new());
+        let motor_driver = L298nDualDriver::new(
+            L298nChannel::new(MockPin::new(0), MockPin::new(0), MockPwmOutput::new()),
+            L298nChannel::new(MockPin::new(0), MockPin::new(0), MockPwmOutput::new()),
+        );
+
         Self {
             board,
             bus,
@@ -91,8 +104,8 @@ impl DeviceSimulationRig {
             imu_sensor,
             imu_frames: demo_raw_frames(),
             imu_frame_index: 0,
-            servo: MockServoMotor::new(),
-            motor_driver: MockDualMotorDriver::new(),
+            servo,
+            motor_driver,
             last_distance_mm: None,
             last_imu: None,
         }
@@ -190,12 +203,12 @@ impl DeviceSimulationRig {
                     .map(|value| value as f32 / 100.0),
             },
             servo: ServoPanelState {
-                angle_degrees: self.servo.angle_degrees(),
+                angle_degrees: self.servo.current_angle(),
             },
             motor_driver: MotorDriverPanelState {
-                driver_name: "L298N-style dual H-bridge".to_string(),
-                left: channel_state(self.motor_driver.left_command()),
-                right: channel_state(self.motor_driver.right_command()),
+                driver_name: "L298N dual H-bridge".to_string(),
+                left: channel_state(self.motor_driver.channel_a().current_command()),
+                right: channel_state(self.motor_driver.channel_b().current_command()),
             },
             wiring: WiringPanelState {
                 sda_pin: self.board.sda_pin().to_string(),

--- a/crates/platform-pc-sim/lib.rs
+++ b/crates/platform-pc-sim/lib.rs
@@ -13,6 +13,7 @@ pub mod hc_sr04_mock;
 pub mod lcd1602_mock;
 pub mod mock_hal;
 pub mod mpu6050_mock;
+pub mod pwm_mock;
 pub mod virtual_i2c;
 pub mod web_dashboard;
 pub mod wiring_config;

--- a/crates/platform-pc-sim/pwm_mock.rs
+++ b/crates/platform-pc-sim/pwm_mock.rs
@@ -1,0 +1,107 @@
+//! Host-side PWM output mock.
+
+use hal_api::error::ActuatorError;
+use hal_api::pwm::PwmOutput;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+#[derive(Debug, Default)]
+struct MockPwmState {
+    duty_percent: u8,
+    history: Vec<u8>,
+}
+
+/// PWM 出力のモック実装。
+///
+/// デューティ比の変更履歴を記録します。
+/// クローン間で内部状態を共有するため、観測用インスタンスからも確認できます。
+#[derive(Clone, Debug, Default)]
+pub struct MockPwmOutput {
+    state: Rc<RefCell<MockPwmState>>,
+}
+
+impl MockPwmOutput {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 現在のデューティ比を返す。
+    pub fn current_duty(&self) -> u8 {
+        self.state.borrow().duty_percent
+    }
+
+    /// 設定されたデューティ比の履歴を返す。
+    pub fn history(&self) -> Vec<u8> {
+        self.state.borrow().history.clone()
+    }
+
+    /// 設定回数を返す。
+    pub fn call_count(&self) -> usize {
+        self.state.borrow().history.len()
+    }
+}
+
+impl PwmOutput for MockPwmOutput {
+    type Error = ActuatorError;
+
+    fn set_duty_percent(&mut self, duty: u8) -> Result<(), Self::Error> {
+        if duty > 100 {
+            return Err(ActuatorError::InvalidCommand);
+        }
+        let mut state = self.state.borrow_mut();
+        state.duty_percent = duty;
+        state.history.push(duty);
+        Ok(())
+    }
+
+    fn duty_percent(&self) -> u8 {
+        self.state.borrow().duty_percent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hal_api::pwm::PwmOutput;
+
+    #[test]
+    fn mock_pwm_tracks_duty_history() {
+        let mut pwm = MockPwmOutput::new();
+        pwm.set_duty_percent(25).unwrap();
+        pwm.set_duty_percent(50).unwrap();
+
+        assert_eq!(pwm.current_duty(), 50);
+        assert_eq!(pwm.history(), vec![25, 50]);
+        assert_eq!(pwm.call_count(), 2);
+    }
+
+    #[test]
+    fn mock_pwm_rejects_duty_over_100() {
+        let mut pwm = MockPwmOutput::new();
+        assert_eq!(
+            pwm.set_duty_percent(101),
+            Err(ActuatorError::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn mock_pwm_clone_shares_state() {
+        let mut pwm = MockPwmOutput::new();
+        let observer = pwm.clone();
+
+        pwm.set_duty_percent(75).unwrap();
+
+        assert_eq!(observer.current_duty(), 75);
+        assert_eq!(observer.history(), vec![75]);
+    }
+
+    #[test]
+    fn mock_pwm_implements_pwm_output_trait() {
+        fn accepts_pwm<T: PwmOutput>(p: &mut T) -> bool {
+            p.set_duty_percent(50).is_ok()
+        }
+        let mut pwm = MockPwmOutput::new();
+        assert!(accepts_pwm(&mut pwm));
+    }
+}

--- a/crates/reference-drivers/l298n.rs
+++ b/crates/reference-drivers/l298n.rs
@@ -1,0 +1,283 @@
+//! L298N-style dual H-bridge motor driver.
+//!
+//! 1ch あたり 2 本の方向制御 GPIO (IN1/IN2) と
+//! 1 本の PWM 速度制御ピン (ENA/ENB) で構成されます。
+//!
+//! # 真理値表 (1 チャンネル)
+//!
+//! | IN1 | IN2 | 動作         |
+//! |-----|-----|--------------|
+//! | H   | L   | 正転 (Forward) |
+//! | L   | H   | 逆転 (Reverse) |
+//! | H   | H   | ブレーキ (Brake) |
+//! | L   | L   | フリー (Coast)  |
+
+use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection};
+use hal_api::error::ActuatorError;
+use hal_api::gpio::OutputPin;
+use hal_api::pwm::PwmOutput;
+
+/// L298N の 1 チャンネル。
+///
+/// `D1`/`D2` は方向制御ピン、`P` は速度制御 PWM ピン。
+pub struct L298nChannel<D1, D2, P> {
+    in1: D1,
+    in2: D2,
+    enable: P,
+    current: MotorCommand,
+}
+
+impl<D1, D2, P> L298nChannel<D1, D2, P>
+where
+    D1: OutputPin,
+    D2: OutputPin,
+    P: PwmOutput,
+    D1::Error: Into<ActuatorError>,
+    D2::Error: Into<ActuatorError>,
+    P::Error: Into<ActuatorError>,
+{
+    pub fn new(in1: D1, in2: D2, enable: P) -> Self {
+        Self {
+            in1,
+            in2,
+            enable,
+            current: MotorCommand::new(MotorDirection::Coast, 0),
+        }
+    }
+
+    /// 最後に適用された指令を返す。
+    pub fn current_command(&self) -> MotorCommand {
+        self.current
+    }
+
+    /// 内部 IN1 ピンへの参照（テスト・観測用）。
+    pub fn in1(&self) -> &D1 {
+        &self.in1
+    }
+
+    /// 内部 IN2 ピンへの参照（テスト・観測用）。
+    pub fn in2(&self) -> &D2 {
+        &self.in2
+    }
+
+    /// 内部 PWM ピンへの参照（テスト・観測用）。
+    pub fn enable(&self) -> &P {
+        &self.enable
+    }
+}
+
+impl<D1, D2, P> DriveMotor for L298nChannel<D1, D2, P>
+where
+    D1: OutputPin,
+    D2: OutputPin,
+    P: PwmOutput,
+    D1::Error: Into<ActuatorError>,
+    D2::Error: Into<ActuatorError>,
+    P::Error: Into<ActuatorError>,
+{
+    type Error = ActuatorError;
+
+    fn apply(&mut self, command: MotorCommand) -> Result<(), Self::Error> {
+        if command.duty_percent > 100 {
+            return Err(ActuatorError::InvalidCommand);
+        }
+        let (in1_high, in2_high) = match command.direction {
+            MotorDirection::Forward => (true, false),
+            MotorDirection::Reverse => (false, true),
+            MotorDirection::Brake => (true, true),
+            MotorDirection::Coast => (false, false),
+        };
+        self.in1.set(in1_high).map_err(Into::into)?;
+        self.in2.set(in2_high).map_err(Into::into)?;
+        self.enable
+            .set_duty_percent(command.duty_percent)
+            .map_err(Into::into)?;
+        self.current = command;
+        Ok(())
+    }
+}
+
+/// L298N の 2 チャンネルまとめ。`A` が左、`B` が右チャンネル。
+pub struct L298nDualDriver<A, B> {
+    channel_a: A,
+    channel_b: B,
+}
+
+impl<A, B> L298nDualDriver<A, B>
+where
+    A: DriveMotor<Error = ActuatorError>,
+    B: DriveMotor<Error = ActuatorError>,
+{
+    pub fn new(channel_a: A, channel_b: B) -> Self {
+        Self {
+            channel_a,
+            channel_b,
+        }
+    }
+
+    /// チャンネル A（左）への参照。
+    pub fn channel_a(&self) -> &A {
+        &self.channel_a
+    }
+
+    /// チャンネル B（右）への参照。
+    pub fn channel_b(&self) -> &B {
+        &self.channel_b
+    }
+}
+
+impl<A, B> DualMotorDriver for L298nDualDriver<A, B>
+where
+    A: DriveMotor<Error = ActuatorError>,
+    B: DriveMotor<Error = ActuatorError>,
+{
+    type Error = ActuatorError;
+
+    fn apply_channels(
+        &mut self,
+        left: MotorCommand,
+        right: MotorCommand,
+    ) -> Result<(), Self::Error> {
+        self.channel_a.apply(left)?;
+        self.channel_b.apply(right)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+
+    struct RecordingPin {
+        level: bool,
+        calls: usize,
+    }
+
+    impl RecordingPin {
+        fn new() -> Self {
+            Self {
+                level: false,
+                calls: 0,
+            }
+        }
+    }
+
+    impl OutputPin for RecordingPin {
+        type Error = ActuatorError;
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            self.level = true;
+            self.calls += 1;
+            Ok(())
+        }
+
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            self.level = false;
+            self.calls += 1;
+            Ok(())
+        }
+    }
+
+    struct RecordingPwm {
+        duty: u8,
+    }
+
+    impl RecordingPwm {
+        fn new() -> Self {
+            Self { duty: 0 }
+        }
+    }
+
+    impl PwmOutput for RecordingPwm {
+        type Error = ActuatorError;
+
+        fn set_duty_percent(&mut self, duty: u8) -> Result<(), Self::Error> {
+            if duty > 100 {
+                return Err(ActuatorError::InvalidCommand);
+            }
+            self.duty = duty;
+            Ok(())
+        }
+
+        fn duty_percent(&self) -> u8 {
+            self.duty
+        }
+    }
+
+    fn make_channel() -> L298nChannel<RecordingPin, RecordingPin, RecordingPwm> {
+        L298nChannel::new(
+            RecordingPin::new(),
+            RecordingPin::new(),
+            RecordingPwm::new(),
+        )
+    }
+
+    #[test]
+    fn l298n_channel_forward_sets_pins_correctly() {
+        let mut ch = make_channel();
+        ch.apply(MotorCommand::new(MotorDirection::Forward, 50))
+            .unwrap();
+        assert!(ch.in1().level);
+        assert!(!ch.in2().level);
+        assert_eq!(ch.enable().duty_percent(), 50);
+        assert_eq!(ch.current_command().direction, MotorDirection::Forward);
+    }
+
+    #[test]
+    fn l298n_channel_reverse_sets_pins_correctly() {
+        let mut ch = make_channel();
+        ch.apply(MotorCommand::new(MotorDirection::Reverse, 40))
+            .unwrap();
+        assert!(!ch.in1().level);
+        assert!(ch.in2().level);
+        assert_eq!(ch.enable().duty_percent(), 40);
+    }
+
+    #[test]
+    fn l298n_channel_brake_sets_both_pins_high() {
+        let mut ch = make_channel();
+        ch.apply(MotorCommand::new(MotorDirection::Brake, 0))
+            .unwrap();
+        assert!(ch.in1().level);
+        assert!(ch.in2().level);
+    }
+
+    #[test]
+    fn l298n_channel_coast_sets_both_pins_low() {
+        let mut ch = make_channel();
+        ch.apply(MotorCommand::new(MotorDirection::Coast, 0))
+            .unwrap();
+        assert!(!ch.in1().level);
+        assert!(!ch.in2().level);
+    }
+
+    #[test]
+    fn l298n_channel_rejects_duty_over_100() {
+        let mut ch = make_channel();
+        assert_eq!(
+            ch.apply(MotorCommand::new(MotorDirection::Forward, 101)),
+            Err(ActuatorError::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn l298n_dual_driver_apply_channels_routes_to_both() {
+        let mut driver = L298nDualDriver::new(make_channel(), make_channel());
+        let left = MotorCommand::new(MotorDirection::Forward, 35);
+        let right = MotorCommand::new(MotorDirection::Reverse, 20);
+
+        driver.apply_channels(left, right).unwrap();
+
+        assert_eq!(
+            driver.channel_a().current_command().direction,
+            MotorDirection::Forward
+        );
+        assert_eq!(driver.channel_a().current_command().duty_percent, 35);
+        assert_eq!(
+            driver.channel_b().current_command().direction,
+            MotorDirection::Reverse
+        );
+        assert_eq!(driver.channel_b().current_command().duty_percent, 20);
+    }
+}

--- a/crates/reference-drivers/lib.rs
+++ b/crates/reference-drivers/lib.rs
@@ -7,5 +7,7 @@
 
 pub mod bme280;
 pub mod hc_sr04;
+pub mod l298n;
 pub mod lcd1602;
 pub mod mpu6050;
+pub mod servo;

--- a/crates/reference-drivers/servo.rs
+++ b/crates/reference-drivers/servo.rs
@@ -1,0 +1,129 @@
+//! Servo motor driver.
+//!
+//! RC サーボの標準的なパルス幅（1–2ms / 20ms 周期）を
+//! PWM デューティ比 5–10 % にマッピングして角度制御を行います。
+
+use hal_api::actuator::ServoMotor;
+use hal_api::error::ActuatorError;
+use hal_api::pwm::PwmOutput;
+
+/// 50 Hz 信号の 0° に対応するデューティ比（1ms / 20ms = 5 %）
+const SERVO_DUTY_MIN: u8 = 5;
+/// 50 Hz 信号の 180° に対応するデューティ比（2ms / 20ms = 10 %）
+const SERVO_DUTY_MAX: u8 = 10;
+
+/// PWM ピンを使ったサーボドライバ。
+///
+/// 0–180 度の角度指令を PWM デューティ比 5–10 % に線形変換します。
+pub struct ServoDriver<P> {
+    pwm: P,
+    current_angle: u16,
+}
+
+impl<P> ServoDriver<P>
+where
+    P: PwmOutput,
+    P::Error: Into<ActuatorError>,
+{
+    /// 90 度（中立位置）で初期化する。
+    pub fn new(pwm: P) -> Self {
+        Self {
+            pwm,
+            current_angle: 90,
+        }
+    }
+
+    /// 最後に設定した角度を返す。
+    pub fn current_angle(&self) -> u16 {
+        self.current_angle
+    }
+
+    /// 内部 PWM への参照（テスト・観測用）。
+    pub fn pwm(&self) -> &P {
+        &self.pwm
+    }
+}
+
+impl<P> ServoMotor for ServoDriver<P>
+where
+    P: PwmOutput,
+    P::Error: Into<ActuatorError>,
+{
+    type Error = ActuatorError;
+
+    fn set_angle_degrees(&mut self, angle_degrees: u16) -> Result<(), Self::Error> {
+        if angle_degrees > 180 {
+            return Err(ActuatorError::InvalidCommand);
+        }
+        let duty = SERVO_DUTY_MIN
+            + (((angle_degrees as u32) * (SERVO_DUTY_MAX - SERVO_DUTY_MIN) as u32) / 180) as u8;
+        self.pwm.set_duty_percent(duty).map_err(Into::into)?;
+        self.current_angle = angle_degrees;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    extern crate std;
+
+    struct SpyPwm {
+        duty: u8,
+        calls: usize,
+    }
+
+    impl SpyPwm {
+        fn new() -> Self {
+            Self { duty: 0, calls: 0 }
+        }
+    }
+
+    impl PwmOutput for SpyPwm {
+        type Error = ActuatorError;
+
+        fn set_duty_percent(&mut self, duty: u8) -> Result<(), Self::Error> {
+            if duty > 100 {
+                return Err(ActuatorError::InvalidCommand);
+            }
+            self.duty = duty;
+            self.calls += 1;
+            Ok(())
+        }
+
+        fn duty_percent(&self) -> u8 {
+            self.duty
+        }
+    }
+
+    #[test]
+    fn servo_driver_maps_zero_degrees_to_min_duty() {
+        let mut driver = ServoDriver::new(SpyPwm::new());
+        driver.set_angle_degrees(0).unwrap();
+        assert_eq!(driver.pwm().duty_percent(), SERVO_DUTY_MIN);
+        assert_eq!(driver.current_angle(), 0);
+    }
+
+    #[test]
+    fn servo_driver_maps_180_degrees_to_max_duty() {
+        let mut driver = ServoDriver::new(SpyPwm::new());
+        driver.set_angle_degrees(180).unwrap();
+        assert_eq!(driver.pwm().duty_percent(), SERVO_DUTY_MAX);
+        assert_eq!(driver.current_angle(), 180);
+    }
+
+    #[test]
+    fn servo_driver_rejects_angle_beyond_180() {
+        let mut driver = ServoDriver::new(SpyPwm::new());
+        assert_eq!(
+            driver.set_angle_degrees(181),
+            Err(ActuatorError::InvalidCommand)
+        );
+    }
+
+    #[test]
+    fn servo_driver_initial_angle_is_90() {
+        let driver = ServoDriver::new(SpyPwm::new());
+        assert_eq!(driver.current_angle(), 90);
+    }
+}


### PR DESCRIPTION
## 概要

Servo と Motor Driver を「driver-backed」にし、シミュレータ内でも実機と同じ reference driver 経路を通るようにしました。

## 変更内容

### hal-api
- **pwm.rs**:  trait を追加（ / ）
- **error.rs**:  変換を追加

### reference-drivers
- **servo.rs**:  を追加。0–180° を PWM デューティ比 5–10%（50Hz RC サーボ標準）に線形マッピング
- **l298n.rs**:  と  を追加。IN1/IN2 (GPIO) + ENA (PWM) で L298N 真理値表を実装

### platform-pc-sim
- **pwm_mock.rs**:  を追加。デューティ比履歴・クローン共有状態・call count

### device_dashboard_web.rs
-  →  に置き換え
-  →  に置き換え

## すべての sensor/actuator が driver-backed になりました

| デバイス | driver-backed? |
|---------|----------------|
| BME280 | ✅ |
| MPU6050 | ✅ |
| HC-SR04 | ✅ |
| LCD1602 | ✅ |
| Servo | ✅ (今回) |
| Motor (L298N) | ✅ (今回) |

## テスト方法

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo check -p reference-drivers --lib --target thumbv6m-none-eabi
cargo run -p platform-pc-sim --bin device-dashboard-web
# http://127.0.0.1:7878 → Servo / Motor Driver パネルを確認
```
