### PR TITLE
test(esp32): add servo + L298N actuator integration tests and ESP32 usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,65 @@ cargo check --release
 cargo run --release
 ```
 
+### Servo / Motor を ESP32 で動かす (PwmOutput bridge)
+
+`ServoDriver` と `L298nDualDriver` は `hal_api::pwm::PwmOutput` / `hal_api::actuator::DriveMotor` に依存しており、
+ESP32 ではアダプタ `Esp32PwmOutput` を介して `embedded-hal::pwm::SetDutyCycle` チャンネルに繋ぐ設計になっています。
+
+```
+ServoDriver<Esp32PwmOutput<LeadcChannel>>
+L298nChannel<Esp32OutputPin<IN1>, Esp32OutputPin<IN2>, Esp32PwmOutput<EnaChannel>>
+L298nDualDriver<ChannelA, ChannelB>
+```
+
+#### 型の組み方（擬似コード）
+
+```rust ignore
+use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+use hal_api::pwm::PwmOutput as _;
+use platform_esp32::{
+    gpio::Esp32OutputPin,
+    pwm::Esp32PwmOutput,
+    servo::ServoDriver,
+    l298n::{L298nChannel, L298nDualDriver},
+};
+
+// LEDC チャンネル（esp-hal の SetDutyCycle 実装）を Esp32PwmOutput でラップ
+let pwm = Esp32PwmOutput::new(ledc_channel); // embedded-hal SetDutyCycle
+let mut servo = ServoDriver::new(pwm);
+
+// 角度を指定（0–180°）
+servo.set_angle_degrees(90).unwrap(); // 7.5% duty
+
+// L298N dual motor driver
+let ch_a = L298nChannel::new(
+    Esp32OutputPin::new(in1_pin),
+    Esp32OutputPin::new(in2_pin),
+    Esp32PwmOutput::new(ena_pwm),
+);
+let ch_b = L298nChannel::new(
+    Esp32OutputPin::new(in3_pin),
+    Esp32OutputPin::new(in4_pin),
+    Esp32PwmOutput::new(enb_pwm),
+);
+let mut driver = L298nDualDriver::new(ch_a, ch_b);
+driver.apply_channels(
+    MotorCommand::new(MotorDirection::Forward, 60), // duty 60%
+    MotorCommand::new(MotorDirection::Reverse, 40),
+).unwrap();
+```
+
+#### duty 計算
+
+| 操作 | 数式 | 例 |
+|------|------|----|
+| `ServoDriver::set_angle_degrees(θ)` | duty = 5 + θ × 5 / 180 % | 0°→5%, 90°→7.5%, 180°→10% |
+| `Esp32PwmOutput::set_duty_percent(d)` | raw = d × max / 100 | max=1000, 7%→70 |
+| `L298nChannel::apply(cmd)` | IN1/IN2 GPIO + ENA duty | Forward=(H,L,60%) |
+
+**注意**: `esp-hal` の LEDC API は crate バージョンにより変わります。
+`Esp32PwmOutput::new(channel)` を呼ぶ前に `channel.set_duty_hz(50)` で 50 Hz を設定しておいてください。
+
 ### M5StickC を診断用 board として使う
 
 M5StickC は `core-app` の本番実行先というより、ESP32 系 board の I2C / button / USB 接続を
@@ -521,7 +580,7 @@ mcu-hal-sim-rs/
 - [ ] `ClimateDisplayApp` の reference path を保ちながら、新しい board / sensor の追加手順を標準化する
 - [ ] `Arduino Nano` の bring-up から `platform-avr` へ還流できる共通 contract を切り出す
 - [ ] `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` のような候補を、共通契約へ還元できる単位で検証する
-- [ ] servo / motor driver の host-side mock を実 driver bridge まで広げる
+- [x] servo / motor driver の host-side mock を実 driver bridge まで広げる（v0.3.1–v0.3.2）
 - [ ] browser dashboard を WebSocket / canvas / wiring editor まで育てる
 - [ ] `EnvSensor` 以外の sensor / actuator lineup も増やし、downstream repo が driver を差し替えやすい状態を作る
 - [ ] publish 対象 crate の release 導線を固める

--- a/crates/platform-esp32/tests/servo_motor_bridge.rs
+++ b/crates/platform-esp32/tests/servo_motor_bridge.rs
@@ -1,0 +1,184 @@
+use core::convert::Infallible;
+
+use embedded_hal::digital::{ErrorType as DigitalErrorType, OutputPin as EmbeddedOutputPin};
+use embedded_hal::pwm::{ErrorType as PwmErrorType, SetDutyCycle};
+use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+use hal_api::pwm::PwmOutput;
+use platform_esp32::gpio::Esp32OutputPin;
+use platform_esp32::l298n::{L298nChannel, L298nDualDriver};
+use platform_esp32::pwm::Esp32PwmOutput;
+use platform_esp32::servo::ServoDriver;
+
+// ---------------------------------------------------------------------------
+// Dummy embedded-hal GPIO pin
+// ---------------------------------------------------------------------------
+
+struct DummyOutputPin {
+    level: bool,
+    call_count: usize,
+}
+
+impl DummyOutputPin {
+    fn new() -> Self {
+        Self {
+            level: false,
+            call_count: 0,
+        }
+    }
+}
+
+impl DigitalErrorType for DummyOutputPin {
+    type Error = Infallible;
+}
+
+impl EmbeddedOutputPin for DummyOutputPin {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.level = true;
+        self.call_count += 1;
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.level = false;
+        self.call_count += 1;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dummy embedded-hal PWM channel
+// ---------------------------------------------------------------------------
+
+struct DummyPwmChannel {
+    duty: u16,
+    max: u16,
+}
+
+impl DummyPwmChannel {
+    fn new(max: u16) -> Self {
+        Self { duty: 0, max }
+    }
+}
+
+impl PwmErrorType for DummyPwmChannel {
+    type Error = Infallible;
+}
+
+impl SetDutyCycle for DummyPwmChannel {
+    fn max_duty_cycle(&self) -> u16 {
+        self.max
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        self.duty = duty;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build an ESP32-backed servo driver
+// ---------------------------------------------------------------------------
+
+fn make_servo() -> ServoDriver<Esp32PwmOutput<DummyPwmChannel>> {
+    ServoDriver::new(Esp32PwmOutput::new(DummyPwmChannel::new(1000)))
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build one L298N channel with ESP32 adapters
+// ---------------------------------------------------------------------------
+
+type Esp32Channel = L298nChannel<
+    Esp32OutputPin<DummyOutputPin>,
+    Esp32OutputPin<DummyOutputPin>,
+    Esp32PwmOutput<DummyPwmChannel>,
+>;
+
+fn make_channel() -> Esp32Channel {
+    L298nChannel::new(
+        Esp32OutputPin::new(DummyOutputPin::new()),
+        Esp32OutputPin::new(DummyOutputPin::new()),
+        Esp32PwmOutput::new(DummyPwmChannel::new(1000)),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn servo_driver_works_with_esp32_pwm_adapter() {
+    let mut servo = make_servo();
+
+    servo.set_angle_degrees(0).unwrap();
+    assert_eq!(servo.current_angle(), 0);
+    // 0° → duty 5% of max 1000 → 50
+    assert_eq!(servo.pwm().duty_percent(), 5);
+
+    servo.set_angle_degrees(90).unwrap();
+    assert_eq!(servo.current_angle(), 90);
+
+    servo.set_angle_degrees(180).unwrap();
+    assert_eq!(servo.current_angle(), 180);
+    // 180° → duty 10% of max 1000 → 100
+    assert_eq!(servo.pwm().duty_percent(), 10);
+}
+
+#[test]
+fn servo_driver_rejects_angle_beyond_180_via_esp32_adapter() {
+    let mut servo = make_servo();
+    assert!(servo.set_angle_degrees(181).is_err());
+}
+
+#[test]
+fn l298n_dual_driver_works_with_esp32_adapters() {
+    let mut driver = L298nDualDriver::new(make_channel(), make_channel());
+
+    let left = MotorCommand::new(MotorDirection::Forward, 60);
+    let right = MotorCommand::new(MotorDirection::Reverse, 40);
+
+    driver.apply_channels(left, right).unwrap();
+
+    assert_eq!(driver.channel_a().current_command().direction, MotorDirection::Forward);
+    assert_eq!(driver.channel_a().current_command().duty_percent, 60);
+    assert_eq!(driver.channel_b().current_command().direction, MotorDirection::Reverse);
+    assert_eq!(driver.channel_b().current_command().duty_percent, 40);
+}
+
+#[test]
+fn l298n_channel_forward_drives_gpio_pins_correctly_via_esp32() {
+    let mut ch = make_channel();
+    ch.apply(MotorCommand::new(MotorDirection::Forward, 75))
+        .unwrap();
+
+    // IN1 = HIGH, IN2 = LOW for Forward
+    assert!(ch.in1().inner().level);
+    assert!(!ch.in2().inner().level);
+    assert_eq!(ch.enable().duty_percent(), 75);
+}
+
+#[test]
+fn l298n_channel_brake_drives_both_pins_high_via_esp32() {
+    let mut ch = make_channel();
+    ch.apply(MotorCommand::new(MotorDirection::Brake, 0)).unwrap();
+
+    assert!(ch.in1().inner().level);
+    assert!(ch.in2().inner().level);
+}
+
+#[test]
+fn full_actuator_scenario_servo_tracks_distance_motor_responds_to_direction() {
+    let mut servo = make_servo();
+    let mut driver = L298nDualDriver::new(make_channel(), make_channel());
+
+    // Simulate: object at 200mm → servo 70°, motors forward
+    let distance_mm: u32 = 200;
+    let angle = ((distance_mm.saturating_sub(80)) * 180 / 280) as u16;
+    servo.set_angle_degrees(angle.min(180)).unwrap();
+
+    let cmd = MotorCommand::new(MotorDirection::Forward, 42);
+    driver.apply_channels(cmd, cmd).unwrap();
+
+    assert!(servo.current_angle() <= 180);
+    assert_eq!(driver.channel_a().current_command().direction, MotorDirection::Forward);
+    assert_eq!(driver.channel_b().current_command().direction, MotorDirection::Forward);
+}

--- a/crates/platform-esp32/tests/servo_motor_bridge.rs
+++ b/crates/platform-esp32/tests/servo_motor_bridge.rs
@@ -138,9 +138,15 @@ fn l298n_dual_driver_works_with_esp32_adapters() {
 
     driver.apply_channels(left, right).unwrap();
 
-    assert_eq!(driver.channel_a().current_command().direction, MotorDirection::Forward);
+    assert_eq!(
+        driver.channel_a().current_command().direction,
+        MotorDirection::Forward
+    );
     assert_eq!(driver.channel_a().current_command().duty_percent, 60);
-    assert_eq!(driver.channel_b().current_command().direction, MotorDirection::Reverse);
+    assert_eq!(
+        driver.channel_b().current_command().direction,
+        MotorDirection::Reverse
+    );
     assert_eq!(driver.channel_b().current_command().duty_percent, 40);
 }
 
@@ -159,7 +165,8 @@ fn l298n_channel_forward_drives_gpio_pins_correctly_via_esp32() {
 #[test]
 fn l298n_channel_brake_drives_both_pins_high_via_esp32() {
     let mut ch = make_channel();
-    ch.apply(MotorCommand::new(MotorDirection::Brake, 0)).unwrap();
+    ch.apply(MotorCommand::new(MotorDirection::Brake, 0))
+        .unwrap();
 
     assert!(ch.in1().inner().level);
     assert!(ch.in2().inner().level);
@@ -179,6 +186,12 @@ fn full_actuator_scenario_servo_tracks_distance_motor_responds_to_direction() {
     driver.apply_channels(cmd, cmd).unwrap();
 
     assert!(servo.current_angle() <= 180);
-    assert_eq!(driver.channel_a().current_command().direction, MotorDirection::Forward);
-    assert_eq!(driver.channel_b().current_command().direction, MotorDirection::Forward);
+    assert_eq!(
+        driver.channel_a().current_command().direction,
+        MotorDirection::Forward
+    );
+    assert_eq!(
+        driver.channel_b().current_command().direction,
+        MotorDirection::Forward
+    );
 }


### PR DESCRIPTION
## 概要

ESP32 アクチュエータ統合テストと README の ESP32 使用ガイドを追加します。

## 変更内容

### `crates/platform-esp32/tests/servo_motor_bridge.rs` (新規)

6 テストを追加 (DummyOutputPin + DummyPwmChannel を使ったエンドツーエンド検証):
- servo_driver_works_with_esp32_pwm_adapter
- servo_driver_rejects_angle_beyond_180_via_esp32_adapter
- l298n_dual_driver_works_with_esp32_adapters
- l298n_channel_forward_drives_gpio_pins_correctly_via_esp32
- l298n_channel_brake_drives_both_pins_high_via_esp32
- full_actuator_scenario_servo_tracks_distance_motor_responds_to_direction

### `README.md`
- 「Servo / Motor を ESP32 で動かす (PwmOutput bridge)」セクションを追加
- duty 計算表、型の組み方（擬似コード）付き
- todo 「servo / motor driver bridge」を完了マーク

## テスト実行
```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
```

## 関連
- #61 (servo + L298N reference-drivers)
- #62 (Esp32PwmOutput adapter)