### PR TITLE
feat: add ESP32 flash API and panel (#66)

### DIFF
--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -429,6 +429,149 @@ fn respond(stream: &mut TcpStream, status: &str, content_type: &str, body: &str)
 /// Stream `cargo test --workspace` output as Server-Sent Events.
 ///
 /// Blocks until the test process exits. Each stdout/stderr line is sent as
+/// Returns available serial ports likely connected to an MCU.
+fn list_serial_ports() -> Vec<String> {
+    let Ok(dir) = std::fs::read_dir("/dev") else {
+        return vec![];
+    };
+    let mut ports: Vec<String> = dir
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().to_string_lossy().to_string())
+        .filter(|name| {
+            // macOS: cu.usbserial*, cu.SLAB*, cu.wchusbserial*, cu.usbmodem*
+            // Linux: ttyUSB*, ttyACM*
+            name.contains("/cu.usbserial")
+                || name.contains("/cu.SLAB")
+                || name.contains("/cu.wchusbserial")
+                || name.contains("/cu.usbmodem")
+                || name.contains("/ttyUSB")
+                || name.contains("/ttyACM")
+        })
+        .collect();
+    ports.sort();
+    ports
+}
+
+/// Streams `espflash flash` output via Server-Sent Events.
+///
+/// Query params: `port=<serial-device>` (optional `bin=<path-to-elf>`)
+/// Graceful degradation: if espflash is not installed, emits an instructional
+/// error event so the UI can display installation guidance.
+fn handle_flash_stream(stream: &mut TcpStream, query: &str) {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+
+    let header = "HTTP/1.1 200 OK\r\n\
+        Content-Type: text/event-stream\r\n\
+        Cache-Control: no-cache\r\n\
+        Connection: keep-alive\r\n\
+        Access-Control-Allow-Origin: *\r\n\
+        \r\n";
+    if stream.write_all(header.as_bytes()).is_err() {
+        return;
+    }
+
+    // Parse query string: port=... (&bin=...)
+    let port = query
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("port="))
+        .unwrap_or("")
+        .to_string();
+    let bin = query
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("bin="))
+        .unwrap_or("")
+        .to_string();
+
+    // Check espflash is available.
+    if std::process::Command::new("espflash")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_err()
+    {
+        let _ = stream.write_all(
+            b"data: [ERROR] espflash not found.\n\n\
+              data: Install: cargo install espflash\n\n\
+              data: Docs: https://github.com/esp-rs/espflash\n\n\
+              data: [DONE] exit=1\n\n",
+        );
+        return;
+    }
+
+    if port.is_empty() {
+        let _ = stream.write_all(
+            b"data: [ERROR] No port specified. Use ?port=/dev/cu.usbserial-XXXX\n\ndata: [DONE] exit=1\n\n",
+        );
+        return;
+    }
+
+    let mut args = vec!["flash".to_string(), "--port".to_string(), port];
+    if !bin.is_empty() {
+        args.push(bin);
+    }
+
+    let mut child = match Command::new("espflash")
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = stream.write_all(
+                format!("data: [ERROR] failed to spawn espflash: {e}\n\ndata: [DONE] exit=1\n\n")
+                    .as_bytes(),
+            );
+            return;
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<String>();
+    let tx_out = tx.clone();
+    let stdout = child.stdout.take().expect("stdout piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if tx_out.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let tx_err = tx.clone();
+    let stderr = child.stderr.take().expect("stderr piped");
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if tx_err.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    drop(tx);
+
+    let started = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(120);
+
+    for line in rx {
+        if started.elapsed() > timeout {
+            let _ = stream.write_all(
+                b"data: [ERROR] timeout: espflash exceeded 2 minutes\n\ndata: [DONE] exit=1\n\n",
+            );
+            let _ = child.kill();
+            return;
+        }
+        let msg = format!("data: {}\n\n", line.replace('\n', " "));
+        if stream.write_all(msg.as_bytes()).is_err() {
+            let _ = child.kill();
+            return;
+        }
+    }
+
+    let exit_code = child.wait().map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+    let _ = stream.write_all(format!("data: [DONE] exit={exit_code}\n\n").as_bytes());
+}
+
 /// `data: {line}\n\n`.  A final `data: [DONE] exit=N\n\n` closes the stream.
 fn handle_test_stream(stream: &mut TcpStream) {
     use std::io::{BufRead, BufReader};
@@ -582,10 +725,11 @@ fn handle_connection(
     let mut parts = first_line.split_whitespace();
     let method = parts.next().unwrap_or("GET");
     let path = parts.next().unwrap_or("/");
+    let (path_only, query_str) = path.split_once('?').unwrap_or((path, ""));
 
     // Check for WebSocket upgrade before HTTP routing.
     let is_ws_upgrade = request.to_ascii_lowercase().contains("upgrade: websocket");
-    if is_ws_upgrade && path == "/api/ws" {
+    if is_ws_upgrade && path_only == "/api/ws" {
         handle_websocket(stream, &request, ctx);
         return;
     }
@@ -595,7 +739,7 @@ fn handle_connection(
         .map(|pos| &request[pos + 4..])
         .unwrap_or("");
 
-    match (method, path) {
+    match (method, path_only) {
         (_, "/") => respond(
             &mut stream,
             "200 OK",
@@ -663,6 +807,26 @@ fn handle_connection(
         }
         (_, "/api/test/stream") => {
             handle_test_stream(&mut stream);
+        }
+        (_, "/api/flash/devices") => {
+            let ports = list_serial_ports();
+            let json = format!(
+                "[{}]",
+                ports
+                    .iter()
+                    .map(|p| format!("\"{}\"", p))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            respond(
+                &mut stream,
+                "200 OK",
+                "application/json; charset=utf-8",
+                &json,
+            );
+        }
+        (_, "/api/flash/stream") => {
+            handle_flash_stream(&mut stream, query_str);
         }
         _ => respond(
             &mut stream,

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -726,6 +726,23 @@ pub fn dashboard_html() -> &'static str {
         <div id="we-status" style="padding:5px 14px;border-top:1px solid var(--line);font-size:11px;color:var(--muted)">Ready &#x2014; drag a device chip to the canvas to get started.</div>
       </article>
 
+      <!-- ESP32 Flash -->
+      <article class="panel card span-12">
+        <h2>&#x26A1; ESP32 Flash</h2>
+        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px">
+          <select id="flash-port" style="min-width:220px">
+            <option value="">-- select port --</option>
+          </select>
+          <button class="btn" onclick="flashRefreshPorts()">&#x1F504; Refresh</button>
+          <input id="flash-bin" type="text" placeholder="path/to/firmware.elf (optional)"
+                 style="flex:1;min-width:200px;background:var(--paper);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:5px 10px;font-size:13px;font-family:inherit"/>
+          <button class="btn" id="flash-btn" onclick="flashStart()">&#x26A1; Flash</button>
+        </div>
+        <div id="flash-output" class="wiring"
+             style="background:#0a0a0a;color:#aaffaa;border-radius:10px;padding:10px 14px;font-size:12px;min-height:80px;max-height:260px;overflow-y:auto;white-space:pre-wrap;font-family:'IBM Plex Mono',monospace"></div>
+        <div id="flash-status" style="margin-top:6px;font-size:11px;color:var(--muted)">Ready.</div>
+      </article>
+
     </section>
   </main>
 
@@ -1299,6 +1316,56 @@ pub fn dashboard_html() -> &'static str {
       document.getElementById('we-status').textContent = 'Canvas cleared.';
     }
     // ── Boot ──
+    // ── ESP32 Flash ──────────────────────────────────────────────────────────
+    async function flashRefreshPorts() {
+      try {
+        const r = await fetch('/api/flash/devices');
+        const ports = await r.json();
+        const sel = document.getElementById('flash-port');
+        sel.innerHTML = '<option value="">-- select port --</option>';
+        ports.forEach(function(p) {
+          const opt = document.createElement('option');
+          opt.value = p; opt.textContent = p;
+          sel.appendChild(opt);
+        });
+        document.getElementById('flash-status').textContent =
+          ports.length ? ports.length + ' port(s) found.' : 'No MCU ports detected.';
+      } catch(err) {
+        document.getElementById('flash-status').textContent = 'Error: ' + err.message;
+      }
+    }
+
+    function flashStart() {
+      const port = document.getElementById('flash-port').value;
+      const bin  = document.getElementById('flash-bin').value.trim();
+      const out  = document.getElementById('flash-output');
+      const btn  = document.getElementById('flash-btn');
+      out.textContent = '';
+      btn.disabled = true;
+      let url = '/api/flash/stream';
+      if (port) url += '?port=' + encodeURIComponent(port);
+      if (bin)  url += (port ? '&' : '?') + 'bin=' + encodeURIComponent(bin);
+      document.getElementById('flash-status').textContent = 'Flashing\u2026';
+      const es = new EventSource(url);
+      es.onmessage = function(e) {
+        if (e.data.startsWith('[DONE]')) {
+          es.close(); btn.disabled = false;
+          const code = e.data.includes('exit=0') ? 0 : 1;
+          document.getElementById('flash-status').textContent =
+            code === 0 ? '\u2705 Flash successful.' : '\u274C Flash failed (see output).';
+        } else {
+          out.textContent += e.data + '\n';
+          out.scrollTop = out.scrollHeight;
+        }
+      };
+      es.onerror = function() {
+        es.close(); btn.disabled = false;
+        document.getElementById('flash-status').textContent = 'Connection error.';
+      };
+    }
+
+    flashRefreshPorts();
+    // ── Boot ──
     connectWs();
   </script>
 </body>
@@ -1352,6 +1419,12 @@ mod tests {
         assert!(html.contains("weExport"));
         assert!(html.contains("weImport"));
         assert!(html.contains("weClear"));
+        // ESP32 flash panel
+        assert!(html.contains("/api/flash/devices"));
+        assert!(html.contains("/api/flash/stream"));
+        assert!(html.contains("flash-port"));
+        assert!(html.contains("flashStart"));
+        assert!(html.contains("flashRefreshPorts"));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Issue #66 の実装です。ESP32 向けのフラッシュ API とダッシュボードパネルを追加しました。

## 変更内容

### バックエンド (`device_dashboard_web.rs`)
- `path/query` を分離（`path_only` + `query_str`）してクエリパラメータをルーティングに利用
- `GET /api/flash/devices`: 接続済みシリアルポートの JSON リストを返す
  - macOS: `/dev/cu.usbserial*`, `/dev/cu.SLAB*`, `/dev/cu.wchusbserial*`, `/dev/cu.usbmodem*`
  - Linux: `/dev/ttyUSB*`, `/dev/ttyACM*`
- `GET /api/flash/stream?port=...&bin=...`: espflash の出力を SSE でストリーミング
  - `espflash` が未インストールの場合はインストール手順をエラーメッセージとして送信（グレースフル デグラデーション）
  - 120 秒タイムアウト付き

### フロントエンド (`web_dashboard.rs`)
- **ESP32 Flash パネル**を追加（span-12）
  - シリアルポートドロップダウン（起動時に自動取得）
  - Refresh ボタン
  - ELF バイナリパス入力フィールド（任意）
  - Flash ボタン → SSE で進捗表示
  - ターミナル風の出力エリア（自動スクロール）

## テスト方法

```bash
cargo test --workspace --all-targets
cargo run -p platform-pc-sim --bin device-dashboard-web
```

ブラウザで http://127.0.0.1:7878 を開き、"ESP32 Flash" パネルを確認。
- `espflash` なしの場合: Flash ボタンを押すとインストール案内が表示される
- `espflash` ありの場合: ポートを選択して Flash ボタンで実機書き込み

Closes #66
