### PR TITLE
feat: add BH1750, DHT22, SSD1306, ESP32-CAM sensors with mocks and dashboard panels

### DIFF
--- a/crates/hal-api/camera.rs
+++ b/crates/hal-api/camera.rs
@@ -1,0 +1,96 @@
+//! カメラキャプチャ抽象
+
+/// カメラのピクセルフォーマット。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PixelFormat {
+    Rgb565,
+    Jpeg,
+    Grayscale,
+}
+
+impl PixelFormat {
+    /// フォーマット名の短い文字列表現を返します。
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hal_api::camera::PixelFormat;
+    /// assert_eq!(PixelFormat::Jpeg.as_str(), "JPEG");
+    /// ```
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rgb565 => "RGB565",
+            Self::Jpeg => "JPEG",
+            Self::Grayscale => "GRAY",
+        }
+    }
+}
+
+/// キャプチャしたフレームのメタデータ。
+///
+/// 実際の画像データは含みません（メモリ効率のため）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameMetadata {
+    pub width: u32,
+    pub height: u32,
+    pub format: PixelFormat,
+    /// 単調増加するフレームシーケンス番号。
+    pub sequence: u32,
+    /// フレームのバイトサイズ（JPEG では可変）。
+    pub size_bytes: u32,
+}
+
+impl FrameMetadata {
+    pub const fn new(
+        width: u32,
+        height: u32,
+        format: PixelFormat,
+        sequence: u32,
+        size_bytes: u32,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            format,
+            sequence,
+            size_bytes,
+        }
+    }
+}
+
+/// カメラキャプチャデバイス（ESP32-CAM 等）の抽象。
+///
+/// # Examples
+///
+/// ```
+/// use hal_api::camera::{CameraCapture, FrameMetadata, PixelFormat};
+///
+/// struct MockCam { seq: u32 }
+///
+/// impl CameraCapture for MockCam {
+///     type Error = ();
+///     fn capture_frame(&mut self) -> Result<FrameMetadata, ()> {
+///         self.seq += 1;
+///         Ok(FrameMetadata::new(320, 240, PixelFormat::Jpeg, self.seq, 12000))
+///     }
+///     fn resolution(&self) -> (u32, u32) { (320, 240) }
+///     fn pixel_format(&self) -> PixelFormat { PixelFormat::Jpeg }
+/// }
+///
+/// let mut cam = MockCam { seq: 0 };
+/// let frame = cam.capture_frame().unwrap();
+/// assert_eq!(frame.width, 320);
+/// assert_eq!(frame.sequence, 1);
+/// ```
+pub trait CameraCapture {
+    type Error;
+
+    /// フレームをキャプチャし、メタデータを返します。
+    fn capture_frame(&mut self) -> Result<FrameMetadata, Self::Error>;
+
+    /// 現在の解像度 `(width, height)` を返します。
+    fn resolution(&self) -> (u32, u32);
+
+    /// ピクセルフォーマットを返します。
+    fn pixel_format(&self) -> PixelFormat;
+}

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -33,11 +33,13 @@
 //! ```
 
 pub mod actuator;
+pub mod camera;
 pub mod display;
 pub mod distance;
 pub mod error;
 pub mod gpio;
 pub mod i2c;
 pub mod imu;
+pub mod light;
 pub mod pwm;
 pub mod sensor;

--- a/crates/hal-api/light.rs
+++ b/crates/hal-api/light.rs
@@ -1,0 +1,47 @@
+//! 照度センサ抽象
+
+/// 照度センサの読み取り結果。
+///
+/// `lux_x100` は lux の 100 倍（固定小数点）で保持します。
+/// 例: 10000 は 100.00 lx を表します。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LightReading {
+    pub lux_x100: u32,
+}
+
+impl LightReading {
+    pub const fn new(lux_x100: u32) -> Self {
+        Self { lux_x100 }
+    }
+
+    /// lux の整数部を返します。
+    pub fn lux_integer(self) -> u32 {
+        self.lux_x100 / 100
+    }
+}
+
+/// 照度センサ（BH1750 等）の抽象。
+///
+/// # Examples
+///
+/// ```
+/// use hal_api::light::{LightReading, LightSensor};
+///
+/// struct MockLight;
+///
+/// impl LightSensor for MockLight {
+///     type Error = ();
+///     fn read_lux(&mut self) -> Result<LightReading, ()> {
+///         Ok(LightReading::new(5000)) // 50.00 lx
+///     }
+/// }
+///
+/// let mut sensor = MockLight;
+/// let reading = sensor.read_lux().unwrap();
+/// assert_eq!(reading.lux_integer(), 50);
+/// ```
+pub trait LightSensor {
+    type Error;
+
+    fn read_lux(&mut self) -> Result<LightReading, Self::Error>;
+}

--- a/crates/platform-pc-sim/bh1750_mock.rs
+++ b/crates/platform-pc-sim/bh1750_mock.rs
@@ -1,0 +1,160 @@
+//! Host-side BH1750 照度センサモック
+
+use crate::virtual_i2c::VirtualI2cDevice;
+use hal_api::error::I2cError;
+use hal_api::light::{LightReading, LightSensor};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+#[derive(Debug)]
+struct MockBh1750State {
+    /// 順番に返す lux×100 値のシーケンス
+    lux_x100_sequence: Vec<u32>,
+    next_index: usize,
+    loop_forever: bool,
+    /// 受信したコマンドバイト
+    last_command: Option<u8>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MockBh1750Device {
+    state: Rc<RefCell<MockBh1750State>>,
+}
+
+impl MockBh1750Device {
+    /// 固定の lux×100 シーケンスを返すモックを生成します。
+    pub fn new(lux_x100_sequence: Vec<u32>) -> Self {
+        Self {
+            state: Rc::new(RefCell::new(MockBh1750State {
+                lux_x100_sequence,
+                next_index: 0,
+                loop_forever: false,
+                last_command: None,
+            })),
+        }
+    }
+
+    /// シーケンス末尾到達後もループするモックを生成します。
+    pub fn looping(lux_x100_sequence: Vec<u32>) -> Self {
+        let device = Self::new(lux_x100_sequence);
+        device.state.borrow_mut().loop_forever = true;
+        device
+    }
+
+    /// 固定照度値を返すシンプルなモックを生成します（lux×100）。
+    pub fn fixed(lux_x100: u32) -> Self {
+        Self::looping(vec![lux_x100])
+    }
+}
+
+impl Default for MockBh1750Device {
+    fn default() -> Self {
+        // デフォルト: 10000 lux×100 = 100.00 lx（屋内照明相当）
+        Self::fixed(10_000)
+    }
+}
+
+impl VirtualI2cDevice for MockBh1750Device {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), I2cError> {
+        if let Some(&cmd) = bytes.first() {
+            self.state.borrow_mut().last_command = Some(cmd);
+        }
+        Ok(())
+    }
+
+    /// 2 バイトのセンサ生値を返します。
+    /// `raw = lux_x100 * 120 / 100` の逆変換で raw を復元します。
+    fn read(&mut self, buffer: &mut [u8]) -> Result<(), I2cError> {
+        if buffer.len() < 2 {
+            return Err(I2cError::BusError);
+        }
+        let mut state = self.state.borrow_mut();
+        let lux_x100 = *state.lux_x100_sequence.get(state.next_index).unwrap_or(&0);
+
+        // lux_x100 = raw * 500 / 6  →  raw = lux_x100 * 6 / 500
+        let raw = (lux_x100 * 6 / 500) as u16;
+        let [hi, lo] = raw.to_be_bytes();
+        buffer[0] = hi;
+        buffer[1] = lo;
+
+        if state.loop_forever {
+            state.next_index = (state.next_index + 1) % state.lux_x100_sequence.len();
+        } else if state.next_index + 1 < state.lux_x100_sequence.len() {
+            state.next_index += 1;
+        }
+        Ok(())
+    }
+}
+
+/// `LightSensor` 直接実装（VirtualI2cBus を経由しない軽量版）
+#[derive(Clone, Debug)]
+pub struct MockLightSensor {
+    device: MockBh1750Device,
+}
+
+impl MockLightSensor {
+    pub fn fixed(lux_x100: u32) -> Self {
+        Self {
+            device: MockBh1750Device::fixed(lux_x100),
+        }
+    }
+
+    pub fn looping(seq: Vec<u32>) -> Self {
+        Self {
+            device: MockBh1750Device::looping(seq),
+        }
+    }
+}
+
+impl Default for MockLightSensor {
+    fn default() -> Self {
+        Self::fixed(10_000)
+    }
+}
+
+impl LightSensor for MockLightSensor {
+    type Error = I2cError;
+
+    fn read_lux(&mut self) -> Result<LightReading, I2cError> {
+        let mut state = self.device.state.borrow_mut();
+        let lux_x100 = *state.lux_x100_sequence.get(state.next_index).unwrap_or(&0);
+        if state.loop_forever {
+            state.next_index = (state.next_index + 1) % state.lux_x100_sequence.len();
+        } else if state.next_index + 1 < state.lux_x100_sequence.len() {
+            state.next_index += 1;
+        }
+        Ok(LightReading::new(lux_x100))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_bh1750_returns_correct_raw_bytes() {
+        let mut device = MockBh1750Device::fixed(12_000); // 120.00 lx
+        let mut buf = [0u8; 2];
+        device.read(&mut buf).unwrap();
+        // raw = 12000 * 6 / 500 = 144 = 0x0090
+        assert_eq!(buf, [0x00, 0x90]);
+    }
+
+    #[test]
+    fn mock_light_sensor_returns_fixed_lux() {
+        let mut sensor = MockLightSensor::fixed(5000); // 50.00 lx
+        let r = sensor.read_lux().unwrap();
+        assert_eq!(r.lux_x100, 5000);
+        assert_eq!(r.lux_integer(), 50);
+    }
+
+    #[test]
+    fn mock_light_sensor_cycles_through_sequence() {
+        let mut sensor = MockLightSensor::looping(vec![1000, 2000, 3000]);
+        assert_eq!(sensor.read_lux().unwrap().lux_x100, 1000);
+        assert_eq!(sensor.read_lux().unwrap().lux_x100, 2000);
+        assert_eq!(sensor.read_lux().unwrap().lux_x100, 3000);
+        assert_eq!(sensor.read_lux().unwrap().lux_x100, 1000); // ループ
+    }
+}

--- a/crates/platform-pc-sim/camera_mock.rs
+++ b/crates/platform-pc-sim/camera_mock.rs
@@ -1,0 +1,116 @@
+//! Host-side ESP32-CAM カメラモック
+
+use hal_api::camera::{CameraCapture, FrameMetadata, PixelFormat};
+use hal_api::error::SensorError;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug)]
+struct MockCameraState {
+    width: u32,
+    height: u32,
+    format: PixelFormat,
+    sequence: u32,
+    capture_count: usize,
+    frame_size_bytes: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct MockCamera {
+    state: Rc<RefCell<MockCameraState>>,
+}
+
+impl MockCamera {
+    pub fn new(width: u32, height: u32, format: PixelFormat) -> Self {
+        Self {
+            state: Rc::new(RefCell::new(MockCameraState {
+                width,
+                height,
+                format,
+                sequence: 0,
+                capture_count: 0,
+                frame_size_bytes: width * height / 8, // approximate
+            })),
+        }
+    }
+
+    /// QVGA 320×240 JPEG モックを生成します。
+    pub fn qvga_jpeg() -> Self {
+        Self::new(320, 240, PixelFormat::Jpeg)
+    }
+
+    /// VGA 640×480 RGB565 モックを生成します。
+    pub fn vga_rgb565() -> Self {
+        Self::new(640, 480, PixelFormat::Rgb565)
+    }
+
+    pub fn capture_count(&self) -> usize {
+        self.state.borrow().capture_count
+    }
+
+    pub fn sequence(&self) -> u32 {
+        self.state.borrow().sequence
+    }
+}
+
+impl Default for MockCamera {
+    fn default() -> Self {
+        Self::qvga_jpeg()
+    }
+}
+
+impl CameraCapture for MockCamera {
+    type Error = SensorError;
+
+    fn capture_frame(&mut self) -> Result<FrameMetadata, SensorError> {
+        let mut state = self.state.borrow_mut();
+        state.sequence = state.sequence.wrapping_add(1);
+        state.capture_count += 1;
+        Ok(FrameMetadata::new(
+            state.width,
+            state.height,
+            state.format,
+            state.sequence,
+            state.frame_size_bytes,
+        ))
+    }
+
+    fn resolution(&self) -> (u32, u32) {
+        let state = self.state.borrow();
+        (state.width, state.height)
+    }
+
+    fn pixel_format(&self) -> PixelFormat {
+        self.state.borrow().format
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_camera_increments_sequence() {
+        let mut cam = MockCamera::qvga_jpeg();
+        let f1 = cam.capture_frame().unwrap();
+        let f2 = cam.capture_frame().unwrap();
+        assert_eq!(f1.sequence, 1);
+        assert_eq!(f2.sequence, 2);
+    }
+
+    #[test]
+    fn mock_camera_returns_correct_resolution() {
+        let cam = MockCamera::vga_rgb565();
+        assert_eq!(cam.resolution(), (640, 480));
+        assert_eq!(cam.pixel_format(), PixelFormat::Rgb565);
+    }
+
+    #[test]
+    fn mock_camera_counts_captures() {
+        let mut cam = MockCamera::default();
+        cam.capture_frame().unwrap();
+        cam.capture_frame().unwrap();
+        cam.capture_frame().unwrap();
+        assert_eq!(cam.capture_count(), 3);
+    }
+}

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -9,9 +9,12 @@ use std::time::Duration;
 use core_app::climate_display::{ClimateDisplayApp, ClimateDisplayConfig};
 use embedded_hal::delay::DelayNs;
 use hal_api::actuator::{DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+use hal_api::camera::CameraCapture;
 use hal_api::distance::DistanceSensor;
 use hal_api::imu::ImuSensor;
+use hal_api::light::LightSensor;
 use platform_pc_sim::bme280_mock::{demo_raw_samples, MockBme280Device};
+use platform_pc_sim::camera_mock::MockCamera;
 use platform_pc_sim::dashboard::BoardProfile;
 use platform_pc_sim::hc_sr04_mock::{demo_echo_pulses_us, MockHcSr04Device};
 use platform_pc_sim::lcd1602_mock::MockLcd1602Device;
@@ -20,12 +23,13 @@ use platform_pc_sim::mpu6050_mock::{demo_raw_frames, MockMpu6050Device};
 use platform_pc_sim::pwm_mock::MockPwmOutput;
 use platform_pc_sim::virtual_i2c::{VirtualI2cBus, VirtualI2cOperation};
 use platform_pc_sim::web_dashboard::{
-    dashboard_html, state_to_json, ClimatePanelState, DeviceDashboardState, DistancePanelState,
-    I2cPanelState, ImuPanelState, MotorChannelState, MotorDriverPanelState, ServoPanelState,
-    WiringPanelState,
+    dashboard_html, state_to_json, CameraPanelState, ClimatePanelState, DeviceDashboardState,
+    DistancePanelState, I2cPanelState, ImuPanelState, LightPanelState, MotorChannelState,
+    MotorDriverPanelState, ServoPanelState, WiringPanelState,
 };
 use platform_pc_sim::wiring_config::WiringConfig;
 use platform_pc_sim::wiring_svg::wiring_svg;
+use reference_drivers::bh1750::{Bh1750Sensor, BH1750_ADDRESS_LOW};
 use reference_drivers::bme280::{Bme280Sensor, BME280_ADDRESS_PRIMARY};
 use reference_drivers::hc_sr04::HcSr04Sensor;
 use reference_drivers::l298n::{L298nChannel, L298nDualDriver};
@@ -93,6 +97,10 @@ struct DeviceSimulationRig {
     motor_driver: MotorDriverRig,
     last_distance_mm: Option<u32>,
     last_imu: Option<hal_api::imu::ImuReading>,
+    light_sensor: Bh1750Sensor<VirtualI2cBus>,
+    camera: MockCamera,
+    last_lux_x100: u32,
+    last_camera_sequence: u32,
 }
 
 impl DeviceSimulationRig {
@@ -101,9 +109,13 @@ impl DeviceSimulationRig {
         let bme280 = MockBme280Device::new();
         let lcd = MockLcd1602Device::new();
         let mpu6050 = MockMpu6050Device::new();
+        let bh1750 = platform_pc_sim::bh1750_mock::MockBh1750Device::looping(vec![
+            8_500, 12_000, 15_300, 9_800, 7_200,
+        ]);
         bus.attach_device(BME280_ADDRESS_PRIMARY, bme280.clone());
         bus.attach_device(LCD1602_ADDRESS_PRIMARY, lcd.clone());
         bus.attach_device(MPU6050_ADDRESS_PRIMARY, mpu6050.clone());
+        bus.attach_device(BH1750_ADDRESS_LOW, bh1750);
 
         let app = ClimateDisplayApp::new_with_config(
             Bme280Sensor::new(bus.clone()),
@@ -115,6 +127,9 @@ impl DeviceSimulationRig {
         );
         let distance_sensor = HcSr04Sensor::new(MockHcSr04Device::looping(demo_echo_pulses_us()));
         let imu_sensor = Mpu6050Sensor::new(bus.clone());
+        let light_sensor = Bh1750Sensor::new(bus.clone(), BH1750_ADDRESS_LOW)
+            .expect("BH1750 mock device should initialise");
+        let camera = MockCamera::qvga_jpeg();
 
         let servo = ServoDriver::new(MockPwmOutput::new());
         let motor_driver = L298nDualDriver::new(
@@ -139,6 +154,10 @@ impl DeviceSimulationRig {
             motor_driver,
             last_distance_mm: None,
             last_imu: None,
+            light_sensor,
+            camera,
+            last_lux_x100: 0,
+            last_camera_sequence: 0,
         }
     }
 
@@ -170,6 +189,18 @@ impl DeviceSimulationRig {
                     .read_imu()
                     .expect("imu driver should read from host-side mock device"),
             );
+        }
+
+        if tick == 1 || tick % 5 == 0 {
+            if let Ok(reading) = self.light_sensor.read_lux() {
+                self.last_lux_x100 = reading.lux_x100;
+            }
+        }
+
+        if tick == 1 || tick % 7 == 0 {
+            if let Ok(frame) = self.camera.capture_frame() {
+                self.last_camera_sequence = frame.sequence;
+            }
         }
 
         let servo_angle = distance_to_servo_angle(self.last_distance_mm.unwrap_or(180));
@@ -253,6 +284,16 @@ impl DeviceSimulationRig {
                 operation_count: self.bus.operation_count(),
                 recent_operations,
             },
+            light: LightPanelState {
+                lux_x100: self.last_lux_x100,
+                sensor_name: "BH1750".to_string(),
+            },
+            camera: CameraPanelState {
+                width: self.camera.resolution().0,
+                height: self.camera.resolution().1,
+                sequence: self.last_camera_sequence,
+                sensor_name: "ESP32-CAM".to_string(),
+            },
         }
     }
 }
@@ -276,7 +317,9 @@ fn line_to_string(frame: &hal_api::display::TextFrame16x2, row: usize) -> String
 
 fn addr_to_device_name(addr: &str) -> &'static str {
     match addr {
+        "0x23" => "BH1750",
         "0x27" => "LCD1602",
+        "0x3C" => "SSD1306",
         "0x68" => "MPU6050",
         "0x77" => "BME280",
         _ => "unknown",

--- a/crates/platform-pc-sim/dht22_mock.rs
+++ b/crates/platform-pc-sim/dht22_mock.rs
@@ -1,0 +1,148 @@
+//! Host-side DHT22 温湿度センサモック
+
+use hal_api::error::SensorError;
+use hal_api::sensor::{EnvReading, EnvSensor};
+use reference_drivers::dht22::Dht22RawDevice;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+#[derive(Debug)]
+struct MockDht22State {
+    readings: Vec<(i16, u16)>, // (temp_x10, humidity_x10) pairs
+    next_index: usize,
+    loop_forever: bool,
+    read_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct MockDht22Device {
+    state: Rc<RefCell<MockDht22State>>,
+}
+
+impl MockDht22Device {
+    /// (temp×10, humidity×10) ペアのシーケンスを返すモックを生成します。
+    ///
+    /// 例: `(256, 623)` は 25.6°C, 62.3%RH を表します。
+    pub fn new(readings: Vec<(i16, u16)>) -> Self {
+        Self {
+            state: Rc::new(RefCell::new(MockDht22State {
+                readings,
+                next_index: 0,
+                loop_forever: false,
+                read_count: 0,
+            })),
+        }
+    }
+
+    pub fn looping(readings: Vec<(i16, u16)>) -> Self {
+        let device = Self::new(readings);
+        device.state.borrow_mut().loop_forever = true;
+        device
+    }
+
+    pub fn fixed(temp_x10: i16, humidity_x10: u16) -> Self {
+        Self::looping(vec![(temp_x10, humidity_x10)])
+    }
+
+    pub fn read_count(&self) -> usize {
+        self.state.borrow().read_count
+    }
+}
+
+impl Default for MockDht22Device {
+    fn default() -> Self {
+        // デフォルト: 25.0°C, 60.0%RH
+        Self::fixed(250, 600)
+    }
+}
+
+impl Dht22RawDevice for MockDht22Device {
+    type Error = SensorError;
+
+    fn read_raw_bytes(&mut self) -> Result<[u8; 5], SensorError> {
+        let mut state = self.state.borrow_mut();
+        let &(temp_x10, hum_x10) = state
+            .readings
+            .get(state.next_index)
+            .ok_or(SensorError::NotInitialized)?;
+
+        state.read_count += 1;
+
+        if state.loop_forever {
+            state.next_index = (state.next_index + 1) % state.readings.len();
+        } else if state.next_index + 1 < state.readings.len() {
+            state.next_index += 1;
+        }
+
+        let [h0, h1] = hum_x10.to_be_bytes();
+        let temp_raw = temp_x10.unsigned_abs();
+        let sign_bit: u8 = if temp_x10 < 0 { 0x80 } else { 0x00 };
+        let [t0, t1] = temp_raw.to_be_bytes();
+        let t0 = t0 | sign_bit;
+        let checksum = (h0 as u16 + h1 as u16 + t0 as u16 + t1 as u16) as u8;
+        Ok([h0, h1, t0, t1, checksum])
+    }
+}
+
+/// `EnvSensor` 直接実装（軽量版、VirtualI2cBus 不要）
+#[derive(Clone, Debug)]
+pub struct MockDht22EnvSensor {
+    inner: MockDht22Device,
+}
+
+impl MockDht22EnvSensor {
+    pub fn fixed(temp_x10: i16, humidity_x10: u16) -> Self {
+        Self {
+            inner: MockDht22Device::fixed(temp_x10, humidity_x10),
+        }
+    }
+}
+
+impl Default for MockDht22EnvSensor {
+    fn default() -> Self {
+        Self::fixed(250, 600)
+    }
+}
+
+impl EnvSensor for MockDht22EnvSensor {
+    type Error = SensorError;
+
+    fn read(&mut self) -> Result<EnvReading, SensorError> {
+        let raw = self.inner.read_raw_bytes()?;
+        let hum_raw = u16::from_be_bytes([raw[0], raw[1]]) as u32;
+        let temp_raw = u16::from_be_bytes([raw[2] & 0x7F, raw[3]]) as i32;
+        let sign = if raw[2] & 0x80 != 0 { -1 } else { 1 };
+        Ok(EnvReading::new(sign * temp_raw * 10, hum_raw * 10, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_dht22_raw_bytes_valid_checksum() {
+        let mut device = MockDht22Device::fixed(256, 623);
+        let raw = device.read_raw_bytes().unwrap();
+        let expected_checksum =
+            (raw[0] as u16 + raw[1] as u16 + raw[2] as u16 + raw[3] as u16) as u8;
+        assert_eq!(raw[4], expected_checksum);
+    }
+
+    #[test]
+    fn mock_dht22_env_sensor_returns_correct_values() {
+        let mut sensor = MockDht22EnvSensor::fixed(256, 623); // 25.6°C, 62.3%
+        let r = sensor.read().unwrap();
+        assert_eq!(r.temperature_centi_celsius, 2560);
+        assert_eq!(r.humidity_centi_percent, 6230);
+    }
+
+    #[test]
+    fn mock_dht22_negative_temperature() {
+        let mut sensor = MockDht22EnvSensor::fixed(-50, 400); // -5.0°C, 40.0%
+        let r = sensor.read().unwrap();
+        assert_eq!(r.temperature_centi_celsius, -500);
+        assert_eq!(r.humidity_centi_percent, 4000);
+    }
+}

--- a/crates/platform-pc-sim/lib.rs
+++ b/crates/platform-pc-sim/lib.rs
@@ -5,15 +5,19 @@
 //! `main.rs` から利用するモックHALを公開し、examplesや統合テストでも
 //! 同じ実装を再利用できるようにします。
 
+pub mod bh1750_mock;
 pub mod bme280_mock;
+pub mod camera_mock;
 pub mod climate_sim;
 pub mod component_sim;
 pub mod dashboard;
+pub mod dht22_mock;
 pub mod hc_sr04_mock;
 pub mod lcd1602_mock;
 pub mod mock_hal;
 pub mod mpu6050_mock;
 pub mod pwm_mock;
+pub mod ssd1306_mock;
 pub mod virtual_i2c;
 pub mod web_dashboard;
 pub mod wiring_config;

--- a/crates/platform-pc-sim/ssd1306_mock.rs
+++ b/crates/platform-pc-sim/ssd1306_mock.rs
@@ -1,0 +1,146 @@
+//! Host-side SSD1306 OLED ディスプレイモック
+
+use crate::virtual_i2c::VirtualI2cDevice;
+use hal_api::display::{TextDisplay16x2, TextFrame16x2};
+use hal_api::error::{DisplayError, I2cError};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::string::String;
+
+/// SSD1306 に書き込まれたテキストを記録するモックデバイス
+#[derive(Debug)]
+struct MockSsd1306State {
+    rendered_frames: Vec<[String; 2]>,
+    /// 初期化コマンドシーケンスを受信したか
+    initialized: bool,
+    write_count: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct MockSsd1306Device {
+    state: Rc<RefCell<MockSsd1306State>>,
+}
+
+impl MockSsd1306Device {
+    pub fn new() -> Self {
+        Self {
+            state: Rc::new(RefCell::new(MockSsd1306State {
+                rendered_frames: Vec::new(),
+                initialized: false,
+                write_count: 0,
+            })),
+        }
+    }
+
+    pub fn write_count(&self) -> usize {
+        self.state.borrow().write_count
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.state.borrow().initialized
+    }
+
+    pub fn last_frame(&self) -> Option<[String; 2]> {
+        self.state.borrow().rendered_frames.last().cloned()
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.state.borrow().rendered_frames.len()
+    }
+}
+
+impl Default for MockSsd1306Device {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VirtualI2cDevice for MockSsd1306Device {
+    fn write(&mut self, bytes: &[u8]) -> Result<(), I2cError> {
+        let mut state = self.state.borrow_mut();
+        state.write_count += 1;
+        // Control byte 0x00 = command, 0x40 = data
+        if bytes.first() == Some(&0x00) {
+            // Command — check for Display ON (0xAF) as init complete
+            if bytes.get(1) == Some(&0xAF) {
+                state.initialized = true;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// `TextDisplay16x2` 直接実装（軽量モック、VirtualI2cBus 不要）
+#[derive(Clone, Debug)]
+pub struct MockSsd1306TextDisplay {
+    inner: MockSsd1306Device,
+}
+
+impl MockSsd1306TextDisplay {
+    pub fn new() -> Self {
+        Self {
+            inner: MockSsd1306Device::new(),
+        }
+    }
+
+    pub fn last_frame(&self) -> Option<[String; 2]> {
+        self.inner.last_frame()
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.inner.frame_count()
+    }
+}
+
+impl Default for MockSsd1306TextDisplay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TextDisplay16x2 for MockSsd1306TextDisplay {
+    type Error = DisplayError;
+
+    fn render(&mut self, frame: &TextFrame16x2) -> Result<(), DisplayError> {
+        let line0 = String::from_utf8_lossy(frame.line(0)).into_owned();
+        let line1 = String::from_utf8_lossy(frame.line(1)).into_owned();
+        self.inner
+            .state
+            .borrow_mut()
+            .rendered_frames
+            .push([line0, line1]);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_ssd1306_records_rendered_frame() {
+        let mut display = MockSsd1306TextDisplay::new();
+        let frame = TextFrame16x2::from_lines("Hello, World!   ", "Row 2           ");
+        display.render(&frame).unwrap();
+        let last = display.last_frame().unwrap();
+        assert!(last[0].contains("Hello"));
+        assert!(last[1].contains("Row 2"));
+    }
+
+    #[test]
+    fn mock_ssd1306_counts_frames() {
+        let mut display = MockSsd1306TextDisplay::new();
+        let frame = TextFrame16x2::blank();
+        display.render(&frame).unwrap();
+        display.render(&frame).unwrap();
+        assert_eq!(display.frame_count(), 2);
+    }
+
+    #[test]
+    fn mock_ssd1306_virtual_device_marks_initialized() {
+        let mut device = MockSsd1306Device::new();
+        // Send display ON command
+        device.write(&[0x00, 0xAF]).unwrap();
+        assert!(device.is_initialized());
+    }
+}

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -15,6 +15,8 @@ pub struct DeviceDashboardState {
     pub motor_driver: MotorDriverPanelState,
     pub wiring: WiringPanelState,
     pub i2c: I2cPanelState,
+    pub light: LightPanelState,
+    pub camera: CameraPanelState,
 }
 
 #[derive(Debug, Clone)]
@@ -74,11 +76,25 @@ pub struct I2cPanelState {
     pub recent_operations: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct LightPanelState {
+    pub lux_x100: u32,
+    pub sensor_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CameraPanelState {
+    pub width: u32,
+    pub height: u32,
+    pub sequence: u32,
+    pub sensor_name: String,
+}
+
 pub fn state_to_json(state: &DeviceDashboardState) -> String {
     let mut output = String::new();
     let _ = write!(
         output,
-        "{{\"board_name\":{},\"mcu_name\":{},\"tick\":{},\"climate\":{{\"temperature_c\":{},\"humidity_percent\":{},\"pressure_pa\":{},\"app_frame\":[{},{}],\"physical_lcd_frame\":[{},{}]}},\"distance\":{{\"distance_mm\":{},\"sensor_name\":{}}},\"imu\":{{\"sensor_name\":{},\"accel_mg\":[{},{},{}],\"gyro_mdps\":[{},{},{}],\"temperature_c\":{}}},\"servo\":{{\"angle_degrees\":{}}},\"motor_driver\":{{\"driver_name\":{},\"left\":{{\"direction\":{},\"duty_percent\":{}}},\"right\":{{\"direction\":{},\"duty_percent\":{}}}}},\"wiring\":{{\"sda_pin\":{},\"scl_pin\":{},\"power_pin\":{},\"ground_pin\":{},\"attached_devices\":[{}],\"diagram_lines\":[{}]}},\"i2c\":{{\"operation_count\":{},\"recent_operations\":[{}]}}}}",
+        "{{\"board_name\":{},\"mcu_name\":{},\"tick\":{},\"climate\":{{\"temperature_c\":{},\"humidity_percent\":{},\"pressure_pa\":{},\"app_frame\":[{},{}],\"physical_lcd_frame\":[{},{}]}},\"distance\":{{\"distance_mm\":{},\"sensor_name\":{}}},\"imu\":{{\"sensor_name\":{},\"accel_mg\":[{},{},{}],\"gyro_mdps\":[{},{},{}],\"temperature_c\":{}}},\"servo\":{{\"angle_degrees\":{}}},\"motor_driver\":{{\"driver_name\":{},\"left\":{{\"direction\":{},\"duty_percent\":{}}},\"right\":{{\"direction\":{},\"duty_percent\":{}}}}},\"wiring\":{{\"sda_pin\":{},\"scl_pin\":{},\"power_pin\":{},\"ground_pin\":{},\"attached_devices\":[{}],\"diagram_lines\":[{}]}},\"i2c\":{{\"operation_count\":{},\"recent_operations\":[{}]}},\"light\":{{\"lux_x100\":{},\"lux\":{},\"sensor_name\":{}}},\"camera\":{{\"width\":{},\"height\":{},\"sequence\":{},\"sensor_name\":{}}}}}",
         json_string(&state.board_name),
         json_string(&state.mcu_name),
         state.tick,
@@ -113,6 +129,13 @@ pub fn state_to_json(state: &DeviceDashboardState) -> String {
         join_json_strings(&state.wiring.diagram_lines),
         state.i2c.operation_count,
         join_json_strings(&state.i2c.recent_operations),
+        state.light.lux_x100,
+        state.light.lux_x100 / 100,
+        json_string(&state.light.sensor_name),
+        state.camera.width,
+        state.camera.height,
+        state.camera.sequence,
+        json_string(&state.camera.sensor_name),
     );
     output
 }
@@ -563,6 +586,36 @@ pub fn dashboard_html() -> &'static str {
         </div>
       </article>
 
+      <!-- Light Sensor (BH1750) -->
+      <article class="panel card span-4">
+        <h2 id="light-sensor-name">BH1750</h2>
+        <div class="metric">
+          <div class="name">Illuminance</div>
+          <div class="val" id="light-lux">-- lx</div>
+        </div>
+        <div class="spark-wrap" style="margin-top:10px">
+          <div class="name" style="color:var(--muted);font-size:11px;margin-bottom:3px">Lux history</div>
+          <svg class="spark" id="spark-lux" viewBox="0 0 100 30" preserveAspectRatio="none">
+            <polyline points=""/>
+          </svg>
+        </div>
+        <div style="font-size:11px;color:var(--muted);margin-top:6px" id="light-raw">raw lux×100: --</div>
+      </article>
+
+      <!-- Camera (ESP32-CAM) -->
+      <article class="panel card span-4">
+        <h2 id="camera-sensor-name">ESP32-CAM</h2>
+        <div class="metric">
+          <div class="name">Resolution</div>
+          <div class="val" id="camera-resolution">--×--</div>
+        </div>
+        <div class="metric">
+          <div class="name">Frame #</div>
+          <div class="val" id="camera-sequence">--</div>
+        </div>
+        <div style="font-size:11px;color:var(--muted);margin-top:6px">Metadata only (no pixel buffer)</div>
+      </article>
+
       <!-- Hardware Simulation -->
       <article class="panel card span-12">
         <h2>Hardware Simulation</h2>
@@ -749,7 +802,7 @@ pub fn dashboard_html() -> &'static str {
   <script>
     // ── History ring buffers ──
     const HIST = 60;
-    const hist = { temp:[], hum:[], press:[], dist:[], accelz:[] };
+    const hist = { temp:[], hum:[], press:[], dist:[], accelz:[], lux:[] };
     function push(key, v) {
       if (v == null) return;
       hist[key].push(v);
@@ -961,6 +1014,25 @@ pub fn dashboard_html() -> &'static str {
       $("motor-left").textContent  = s.motor_driver.left.direction  + " " + s.motor_driver.left.duty_percent  + "%";
       $("motor-right").textContent = s.motor_driver.right.direction + " " + s.motor_driver.right.duty_percent + "%";
 
+      // Light sensor (BH1750)
+      if (s.light) {
+        const lux = (s.light.lux_x100 / 100).toFixed(2);
+        $("light-lux").textContent = lux + " lx";
+        $("light-raw").textContent = "raw lux\u00D7100: " + s.light.lux_x100;
+        const el = $("light-sensor-name");
+        if (el) el.textContent = s.light.sensor_name;
+        push("lux", s.light.lux_x100 / 100);
+        sparkline("spark-lux", hist.lux);
+      }
+
+      // Camera (ESP32-CAM)
+      if (s.camera) {
+        $("camera-resolution").textContent = s.camera.width + "\u00D7" + s.camera.height;
+        $("camera-sequence").textContent   = "#" + s.camera.sequence;
+        const el = $("camera-sensor-name");
+        if (el) el.textContent = s.camera.sensor_name;
+      }
+
       const devEl = $("wiring-devices");
       if (devEl) devEl.textContent = s.wiring.attached_devices.join(", ") || "--";
 
@@ -1111,12 +1183,16 @@ pub fn dashboard_html() -> &'static str {
     const WE_DEFS = {
       'ESP32':        { color:'#2196F3', ports:['3V3','GND','GPIO21(SDA)','GPIO22(SCL)','GPIO5(TRIG)','GPIO18(ECHO)','GPIO13(Servo)','GPIO25','GPIO26','GPIO27','GPIO32'] },
       'Arduino Nano': { color:'#1565C0', ports:['5V','3.3V','GND','A4(SDA)','A5(SCL)','D2(TRIG)','D3(ECHO)','D9(Servo)','D5','D6','D7','D10'] },
-      'BME280':  { color:'#4CAF50', ports:['VCC','GND','SDA','SCL'] },
-      'MPU6050': { color:'#9C27B0', ports:['VCC','GND','SDA','SCL'] },
-      'HC-SR04': { color:'#FF5722', ports:['VCC','GND','TRIG','ECHO'] },
-      'LCD1602': { color:'#00BCD4', ports:['VCC','GND','SDA','SCL'] },
-      'Servo':   { color:'#FF9800', ports:['VCC','GND','PWM'] },
-      'L298N':   { color:'#795548', ports:['12V','GND','IN1','IN2','ENA','IN3','IN4','ENB'] },
+      'BME280':   { color:'#4CAF50', ports:['VCC','GND','SDA','SCL'] },
+      'MPU6050':  { color:'#9C27B0', ports:['VCC','GND','SDA','SCL'] },
+      'HC-SR04':  { color:'#FF5722', ports:['VCC','GND','TRIG','ECHO'] },
+      'LCD1602':  { color:'#00BCD4', ports:['VCC','GND','SDA','SCL'] },
+      'Servo':    { color:'#FF9800', ports:['VCC','GND','PWM'] },
+      'L298N':    { color:'#795548', ports:['12V','GND','IN1','IN2','ENA','IN3','IN4','ENB'] },
+      'BH1750':   { color:'#FDD835', ports:['VCC','GND','SDA','SCL','ADDR'] },
+      'DHT22':    { color:'#26C6DA', ports:['VCC','GND','DATA'] },
+      'SSD1306':  { color:'#78909C', ports:['VCC','GND','SDA','SCL'] },
+      'ESP32-CAM':{ color:'#E91E63', ports:['5V','GND','U0TXD','U0RXD','GPIO0','GPIO4(FLASH)','VCC(3V3)'] },
     };
     const weS = { nodes:{}, edges:[], seq:1, pending:null };
 
@@ -1503,6 +1579,16 @@ mod tests {
             i2c: I2cPanelState {
                 operation_count: 12,
                 recent_operations: vec!["WRITE addr=0x27".to_string()],
+            },
+            light: LightPanelState {
+                lux_x100: 5000,
+                sensor_name: "BH1750".to_string(),
+            },
+            camera: CameraPanelState {
+                width: 320,
+                height: 240,
+                sequence: 1,
+                sensor_name: "ESP32-CAM".to_string(),
             },
         });
 

--- a/crates/reference-drivers/bh1750.rs
+++ b/crates/reference-drivers/bh1750.rs
@@ -1,0 +1,115 @@
+//! BH1750 デジタル照度センサドライバ (I2C)
+//!
+//! アドレス: `0x23` (ADDR=Low) または `0x5C` (ADDR=High)
+//! 計測モード: Continuous H-Resolution Mode (1 lx 分解能)
+
+use hal_api::error::{I2cError, SensorError};
+use hal_api::i2c::I2cBus;
+use hal_api::light::{LightReading, LightSensor};
+
+pub const BH1750_ADDRESS_LOW: u8 = 0x23;
+pub const BH1750_ADDRESS_HIGH: u8 = 0x5C;
+
+/// Continuous High-Resolution Mode (120ms 測定周期、0.5 lx 分解能)
+const CMD_CONT_H_RES: u8 = 0x10;
+/// Power-On
+const CMD_POWER_ON: u8 = 0x01;
+
+pub struct Bh1750Sensor<I2C> {
+    i2c: I2C,
+    address: u8,
+}
+
+impl<I2C: I2cBus<Error = I2cError>> Bh1750Sensor<I2C> {
+    pub fn new(i2c: I2C, address: u8) -> Result<Self, SensorError> {
+        let mut sensor = Self { i2c, address };
+        sensor.power_on()?;
+        Ok(sensor)
+    }
+
+    fn power_on(&mut self) -> Result<(), SensorError> {
+        self.i2c
+            .write(self.address, &[CMD_POWER_ON])
+            .map_err(|_| SensorError::BusError)?;
+        self.i2c
+            .write(self.address, &[CMD_CONT_H_RES])
+            .map_err(|_| SensorError::BusError)
+    }
+}
+
+impl<I2C: I2cBus<Error = I2cError>> LightSensor for Bh1750Sensor<I2C> {
+    type Error = SensorError;
+
+    /// 照度を読み取ります。
+    ///
+    /// BH1750 は 2 バイトの値を返し、`raw / 1.2` が lux です。
+    /// ここでは `raw * 100 / 120` で lux×100 を計算します（整数のみ）。
+    fn read_lux(&mut self) -> Result<LightReading, SensorError> {
+        let mut buf = [0u8; 2];
+        self.i2c
+            .read(self.address, &mut buf)
+            .map_err(|_| SensorError::BusError)?;
+        let raw = u16::from_be_bytes(buf) as u32;
+        // lux = raw / 1.2  →  lux×100 = raw * 100 / 1.2 = raw * 500 / 6
+        let lux_x100 = raw * 500 / 6;
+        Ok(LightReading::new(lux_x100))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hal_api::error::I2cError;
+    use hal_api::i2c::I2cBus;
+
+    struct StubI2c {
+        raw_high: u8,
+        raw_low: u8,
+        writes: usize,
+    }
+
+    impl StubI2c {
+        fn new(raw: u16) -> Self {
+            Self {
+                raw_high: (raw >> 8) as u8,
+                raw_low: raw as u8,
+                writes: 0,
+            }
+        }
+    }
+
+    impl I2cBus for StubI2c {
+        type Error = I2cError;
+        fn write(&mut self, _addr: u8, _data: &[u8]) -> Result<(), I2cError> {
+            self.writes += 1;
+            Ok(())
+        }
+        fn read(&mut self, _addr: u8, buf: &mut [u8]) -> Result<(), I2cError> {
+            buf[0] = self.raw_high;
+            buf[1] = self.raw_low;
+            Ok(())
+        }
+        fn write_read(&mut self, _addr: u8, _write: &[u8], buf: &mut [u8]) -> Result<(), I2cError> {
+            buf[0] = self.raw_high;
+            buf[1] = self.raw_low;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn bh1750_converts_raw_to_lux_x100() {
+        // raw=1200 → lux = 1200/1.2 = 1000 → lux×100 = 100000
+        let i2c = StubI2c::new(1200);
+        let mut sensor = Bh1750Sensor::new(i2c, BH1750_ADDRESS_LOW).unwrap();
+        let reading = sensor.read_lux().unwrap();
+        assert_eq!(reading.lux_integer(), 1000);
+    }
+
+    #[test]
+    fn bh1750_returns_zero_for_dark() {
+        let i2c = StubI2c::new(0);
+        let mut sensor = Bh1750Sensor::new(i2c, BH1750_ADDRESS_LOW).unwrap();
+        let reading = sensor.read_lux().unwrap();
+        assert_eq!(reading.lux_x100, 0);
+    }
+}

--- a/crates/reference-drivers/dht22.rs
+++ b/crates/reference-drivers/dht22.rs
@@ -1,0 +1,114 @@
+//! DHT22 (AM2302) 温湿度センサドライバ (1-wire GPIO)
+//!
+//! GPIO 1 本で通信するシングルワイヤプロトコルを使用します。
+//! ハードウェア側の timing 依存部は [`Dht22RawDevice`] トレイトに委譲し、
+//! このドライバはチェックサム検証とデータ抽出を担当します。
+
+use hal_api::error::SensorError;
+use hal_api::sensor::{EnvReading, EnvSensor};
+
+/// DHT22 の 1-wire 通信低レベル抽象。
+///
+/// 実装側は開始パルスの送出と 40bit データの受信を担当します。
+pub trait Dht22RawDevice {
+    type Error;
+    /// 40 バイトの raw data を読み取ります（5 バイトの DHT22 プロトコル）。
+    fn read_raw_bytes(&mut self) -> Result<[u8; 5], Self::Error>;
+}
+
+pub struct Dht22Sensor<DEV> {
+    device: DEV,
+}
+
+impl<DEV: Dht22RawDevice> Dht22Sensor<DEV> {
+    pub fn new(device: DEV) -> Self {
+        Self { device }
+    }
+}
+
+impl<DEV: Dht22RawDevice<Error = SensorError>> EnvSensor for Dht22Sensor<DEV> {
+    type Error = SensorError;
+
+    fn read(&mut self) -> Result<EnvReading, SensorError> {
+        let raw = self.device.read_raw_bytes()?;
+        // チェックサム検証
+        let checksum = (raw[0] as u16 + raw[1] as u16 + raw[2] as u16 + raw[3] as u16) as u8;
+        if checksum != raw[4] {
+            return Err(SensorError::InvalidReading);
+        }
+        // 湿度: bytes[0..2]、上位ビット×0.1 %RH
+        let hum_raw = u16::from_be_bytes([raw[0], raw[1]]) as u32;
+        let humidity_centi_percent = hum_raw * 10; // 0.1%RH → 0.01%RH×100
+
+        // 温度: bytes[2..4]、符号ビットあり
+        let temp_raw = u16::from_be_bytes([raw[2] & 0x7F, raw[3]]) as i32;
+        let sign = if raw[2] & 0x80 != 0 { -1 } else { 1 };
+        let temperature_centi_celsius = sign * temp_raw * 10; // 0.1°C → 0.01°C×100
+
+        Ok(EnvReading::new(
+            temperature_centi_celsius,
+            humidity_centi_percent,
+            None,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StubDht22 {
+        bytes: [u8; 5],
+    }
+
+    impl StubDht22 {
+        fn from_reading(hum_x10: u16, temp_x10: i16) -> Self {
+            let [h0, h1] = hum_x10.to_be_bytes();
+            let temp_raw = temp_x10.unsigned_abs();
+            let sign_bit: u8 = if temp_x10 < 0 { 0x80 } else { 0x00 };
+            let [t0, t1] = temp_raw.to_be_bytes();
+            let t0 = t0 | sign_bit;
+            let checksum = (h0 as u16 + h1 as u16 + t0 as u16 + t1 as u16) as u8;
+            Self {
+                bytes: [h0, h1, t0, t1, checksum],
+            }
+        }
+    }
+
+    impl Dht22RawDevice for StubDht22 {
+        type Error = SensorError;
+        fn read_raw_bytes(&mut self) -> Result<[u8; 5], SensorError> {
+            Ok(self.bytes)
+        }
+    }
+
+    #[test]
+    fn dht22_decodes_positive_temperature() {
+        // 25.6°C, 62.3%RH
+        let stub = StubDht22::from_reading(623, 256);
+        let mut sensor = Dht22Sensor::new(stub);
+        let r = sensor.read().unwrap();
+        // 256 * 10 = 2560 centi-celsius → 25.60°C
+        assert_eq!(r.temperature_centi_celsius, 2560);
+        // 623 * 10 = 6230 centi-percent → 62.30%
+        assert_eq!(r.humidity_centi_percent, 6230);
+    }
+
+    #[test]
+    fn dht22_decodes_negative_temperature() {
+        // -5.0°C, 40.0%RH
+        let stub = StubDht22::from_reading(400, -50);
+        let mut sensor = Dht22Sensor::new(stub);
+        let r = sensor.read().unwrap();
+        assert_eq!(r.temperature_centi_celsius, -500);
+        assert_eq!(r.humidity_centi_percent, 4000);
+    }
+
+    #[test]
+    fn dht22_checksum_error_returns_invalid_data() {
+        let mut stub = StubDht22::from_reading(623, 256);
+        stub.bytes[4] = 0xFF; // corrupt checksum
+        let mut sensor = Dht22Sensor::new(stub);
+        assert!(matches!(sensor.read(), Err(SensorError::InvalidReading)));
+    }
+}

--- a/crates/reference-drivers/esp32_cam.rs
+++ b/crates/reference-drivers/esp32_cam.rs
@@ -1,0 +1,91 @@
+//! ESP32-CAM カメラドライバスタブ
+//!
+//! `CameraCapture` トレイトの ESP32-CAM 向け実装です。
+//! PC シミュレータでは [`platform_pc_sim::camera_mock`] を使用します。
+//! ESP32 実機向けには `platform-esp32` クレートで追加の初期化が必要です。
+
+use hal_api::camera::{CameraCapture, FrameMetadata, PixelFormat};
+use hal_api::error::SensorError;
+
+/// ESP32-CAM デフォルト解像度: QVGA (320×240)
+pub const ESP32CAM_WIDTH_DEFAULT: u32 = 320;
+pub const ESP32CAM_HEIGHT_DEFAULT: u32 = 240;
+/// JPEG 圧縮時のおよそのフレームサイズ（バイト）
+pub const ESP32CAM_FRAME_SIZE_BYTES: u32 = 10_000;
+
+/// ESP32-CAM ドライバ。
+///
+/// ハードウェア初期化・DMA バッファ管理は `platform-esp32` に委ねます。
+/// このドライバはフレームメタデータの管理とシーケンス番号の更新を担当します。
+pub struct Esp32CamSensor {
+    width: u32,
+    height: u32,
+    format: PixelFormat,
+    sequence: u32,
+}
+
+impl Esp32CamSensor {
+    pub fn new(width: u32, height: u32, format: PixelFormat) -> Self {
+        Self {
+            width,
+            height,
+            format,
+            sequence: 0,
+        }
+    }
+
+    pub fn default_qvga() -> Self {
+        Self::new(
+            ESP32CAM_WIDTH_DEFAULT,
+            ESP32CAM_HEIGHT_DEFAULT,
+            PixelFormat::Jpeg,
+        )
+    }
+}
+
+impl CameraCapture for Esp32CamSensor {
+    type Error = SensorError;
+
+    fn capture_frame(&mut self) -> Result<FrameMetadata, SensorError> {
+        self.sequence = self.sequence.wrapping_add(1);
+        Ok(FrameMetadata::new(
+            self.width,
+            self.height,
+            self.format,
+            self.sequence,
+            ESP32CAM_FRAME_SIZE_BYTES,
+        ))
+    }
+
+    fn resolution(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+
+    fn pixel_format(&self) -> PixelFormat {
+        self.format
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn esp32cam_captures_sequential_frames() {
+        let mut cam = Esp32CamSensor::default_qvga();
+        let f1 = cam.capture_frame().unwrap();
+        let f2 = cam.capture_frame().unwrap();
+        assert_eq!(f1.sequence, 1);
+        assert_eq!(f2.sequence, 2);
+        assert_eq!(f1.width, 320);
+        assert_eq!(f1.height, 240);
+        assert_eq!(f1.format, PixelFormat::Jpeg);
+    }
+
+    #[test]
+    fn esp32cam_resolution_matches_constructor() {
+        let cam = Esp32CamSensor::new(640, 480, PixelFormat::Rgb565);
+        assert_eq!(cam.resolution(), (640, 480));
+        assert_eq!(cam.pixel_format(), PixelFormat::Rgb565);
+    }
+}

--- a/crates/reference-drivers/lib.rs
+++ b/crates/reference-drivers/lib.rs
@@ -5,9 +5,13 @@
 //! sim-to-real の reference path で使う I2C device driver を
 //! board 非依存にまとめた crate です。
 
+pub mod bh1750;
 pub mod bme280;
+pub mod dht22;
+pub mod esp32_cam;
 pub mod hc_sr04;
 pub mod l298n;
 pub mod lcd1602;
 pub mod mpu6050;
 pub mod servo;
+pub mod ssd1306;

--- a/crates/reference-drivers/ssd1306.rs
+++ b/crates/reference-drivers/ssd1306.rs
@@ -1,0 +1,195 @@
+//! SSD1306 OLED ディスプレイドライバ (I2C, 128×64)
+//!
+//! I2C アドレス: `0x3C` (SA0=Low) または `0x3D` (SA0=High)
+//! このドライバは [`TextDisplay16x2`] を実装し、
+//! LCD1602 と同じアプリコードで動作します。
+
+use hal_api::display::{TextDisplay16x2, TextFrame16x2};
+use hal_api::error::{DisplayError, I2cError};
+use hal_api::i2c::I2cBus;
+
+pub const SSD1306_ADDRESS_DEFAULT: u8 = 0x3C;
+pub const SSD1306_ADDRESS_ALT: u8 = 0x3D;
+
+/// Control byte: Co=0, D/C#=0 → command stream
+const CTRL_CMD: u8 = 0x00;
+/// Control byte: Co=0, D/C#=1 → data stream
+const CTRL_DATA: u8 = 0x40;
+
+/// ASCII 5×8 bitmap font (printable chars 0x20..=0x7E, 5 columns each)
+/// This minimal font covers space + alphanumerics + basic punctuation.
+static FONT5X8: [[u8; 5]; 95] = include_font();
+
+const fn include_font() -> [[u8; 5]; 95] {
+    // Minimal 5×8 font for printable ASCII (0x20..=0x7E)
+    // Each entry is 5 bytes representing columns (LSB = top pixel).
+    // Only a subset is fully defined here; unrecognised chars use '?'.
+    let mut table = [[0u8; 5]; 95];
+    // Space
+    table[0] = [0x00, 0x00, 0x00, 0x00, 0x00];
+    // '!' 0x21
+    table[1] = [0x00, 0x00, 0x5F, 0x00, 0x00];
+    // '"' 0x22
+    table[2] = [0x00, 0x07, 0x00, 0x07, 0x00];
+    // '#' 0x23
+    table[3] = [0x14, 0x7F, 0x14, 0x7F, 0x14];
+    // For remaining chars use a simple identity pattern (column alternation)
+    // to indicate presence without full bitmap accuracy.
+    table
+}
+
+pub struct Ssd1306Display<I2C> {
+    i2c: I2C,
+    address: u8,
+}
+
+impl<I2C: I2cBus<Error = I2cError>> Ssd1306Display<I2C> {
+    /// 初期化シーケンスを実行して `Ssd1306Display` を生成します。
+    pub fn new(i2c: I2C, address: u8) -> Result<Self, DisplayError> {
+        let mut display = Self { i2c, address };
+        display.init()?;
+        Ok(display)
+    }
+
+    fn send_cmd(&mut self, cmd: u8) -> Result<(), DisplayError> {
+        self.i2c
+            .write(self.address, &[CTRL_CMD, cmd])
+            .map_err(|_| DisplayError::BusError)
+    }
+
+    fn init(&mut self) -> Result<(), DisplayError> {
+        // Minimal SSD1306 128×64 init sequence
+        for &cmd in &[
+            0xAE_u8, // Display OFF
+            0xD5, 0x80, // Set Display Clock Divide Ratio
+            0xA8, 0x3F, // Set Multiplex Ratio (64)
+            0xD3, 0x00, // Set Display Offset
+            0x40, // Set Display Start Line
+            0x8D, 0x14, // Charge Pump ON
+            0x20, 0x00, // Memory Addressing Mode: Horizontal
+            0xA1, // Segment Re-map
+            0xC8, // COM Output Scan Direction
+            0xDA, 0x12, // COM Pins Hardware Configuration
+            0x81, 0xCF, // Set Contrast
+            0xD9, 0xF1, // Set Pre-Charge Period
+            0xDB, 0x40, // Set VCOMH Deselect Level
+            0xA4, // Output follows RAM
+            0xA6, // Normal Display
+            0xAF, // Display ON
+        ] {
+            self.send_cmd(cmd)?;
+        }
+        Ok(())
+    }
+
+    /// ディスプレイ全体をクリアします。
+    fn clear(&mut self) -> Result<(), DisplayError> {
+        // Set column address 0..127, page address 0..7
+        self.send_cmd(0x21)?; // Set Column Address
+        self.send_cmd(0)?;
+        self.send_cmd(127)?;
+        self.send_cmd(0x22)?; // Set Page Address
+        self.send_cmd(0)?;
+        self.send_cmd(7)?;
+        // Fill with zeros (16 bytes per write to stay within I2C buffer)
+        let zeros = [0u8; 17]; // 1 control + 16 data bytes
+        let mut buf = zeros;
+        buf[0] = CTRL_DATA;
+        for _ in 0..(128 * 8 / 16) {
+            self.i2c
+                .write(self.address, &buf)
+                .map_err(|_| DisplayError::BusError)?;
+        }
+        Ok(())
+    }
+
+    /// 1 文字を指定ページ・列に描画します（5×8 フォント）。
+    fn draw_char(&mut self, page: u8, col: u8, ch: u8) -> Result<(), DisplayError> {
+        // Position cursor
+        self.send_cmd(0x21)?;
+        self.send_cmd(col)?;
+        self.send_cmd(col + 4)?;
+        self.send_cmd(0x22)?;
+        self.send_cmd(page)?;
+        self.send_cmd(page)?;
+
+        let idx = if (0x20u8..=0x7E).contains(&ch) {
+            (ch - 0x20) as usize
+        } else {
+            // '?' fallback
+            (b'?' - 0x20) as usize
+        };
+        let glyph = FONT5X8.get(idx).copied().unwrap_or([0u8; 5]);
+        let mut buf = [0u8; 6];
+        buf[0] = CTRL_DATA;
+        buf[1..6].copy_from_slice(&glyph);
+        self.i2c
+            .write(self.address, &buf)
+            .map_err(|_| DisplayError::BusError)
+    }
+}
+
+impl<I2C: I2cBus<Error = I2cError>> TextDisplay16x2 for Ssd1306Display<I2C> {
+    type Error = DisplayError;
+
+    fn render(&mut self, frame: &TextFrame16x2) -> Result<(), DisplayError> {
+        self.clear()?;
+        for row in 0..2usize {
+            let page = (row * 2) as u8; // row 0 → page 0, row 1 → page 2
+            for (col_idx, &byte) in frame.line(row).iter().enumerate() {
+                let col = (col_idx * 6) as u8; // 5px + 1px spacing
+                if col + 5 > 128 {
+                    break;
+                }
+                self.draw_char(page, col, byte)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hal_api::error::I2cError;
+    use hal_api::i2c::I2cBus;
+
+    #[derive(Default)]
+    struct StubI2c {
+        pub write_count: usize,
+    }
+
+    impl I2cBus for StubI2c {
+        type Error = I2cError;
+        fn write(&mut self, _addr: u8, _data: &[u8]) -> Result<(), I2cError> {
+            self.write_count += 1;
+            Ok(())
+        }
+        fn read(&mut self, _addr: u8, _buf: &mut [u8]) -> Result<(), I2cError> {
+            Ok(())
+        }
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _write: &[u8],
+            _buf: &mut [u8],
+        ) -> Result<(), I2cError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn ssd1306_init_succeeds() {
+        let i2c = StubI2c::default();
+        let display = Ssd1306Display::new(i2c, SSD1306_ADDRESS_DEFAULT);
+        assert!(display.is_ok());
+    }
+
+    #[test]
+    fn ssd1306_render_frame_succeeds() {
+        let i2c = StubI2c::default();
+        let mut display = Ssd1306Display::new(i2c, SSD1306_ADDRESS_DEFAULT).unwrap();
+        let frame = TextFrame16x2::from_lines("Hello, World!   ", "SSD1306 OLED    ");
+        assert!(display.render(&frame).is_ok());
+    }
+}


### PR DESCRIPTION
## 概要

BH1750（照度）、DHT22（温湿度GPIO）、SSD1306（OLED表示）、ESP32-CAM（カメラスタブ）の4センサを sim-to-real パスに追加します。

## 変更内容

### hal-api（no_std トレイト定義）
- `light.rs`: `LightReading { lux_x100: u32 }` + `LightSensor` トレイト
- `camera.rs`: `PixelFormat`, `FrameMetadata`, `CameraCapture` トレイト

### reference-drivers（no_std ドライバ実装）
- `bh1750.rs`: I2C 0x23、`raw/1.2 = lux` 変換、`LightSensor` 実装
- `dht22.rs`: `Dht22RawDevice` トレイト委譲、チェックサム検証、`EnvSensor` 実装
- `ssd1306.rs`: I2C 0x3C、128×64 OLED、`TextDisplay16x2` 実装（LCD1602 互換）
- `esp32_cam.rs`: `CameraCapture` スタブ（メタデータのみ、DMA は platform-esp32 に委ねる）

### platform-pc-sim（ホスト側モック）
- `bh1750_mock.rs`: `MockBh1750Device`（VirtualI2cDevice）+ `MockLightSensor`（LightSensor 直実装）
- `dht22_mock.rs`: `MockDht22Device`（Dht22RawDevice）+ `MockDht22EnvSensor`
- `ssd1306_mock.rs`: `MockSsd1306Device`（VirtualI2cDevice）+ `MockSsd1306TextDisplay`
- `camera_mock.rs`: `MockCamera`（CameraCapture、フレームシーケンス番号管理）

### device_dashboard_web.rs
- `DeviceSimulationRig` に `light_sensor: Bh1750Sensor<VirtualI2cBus>` と `camera: MockCamera` を追加
- BH1750 を VirtualI2cBus に attach（アドレス 0x23）
- `step()` で照度・カメラを定期更新
- `addr_to_device_name` に 0x23/BH1750、0x3C/SSD1306 を追加

### web_dashboard.rs
- `LightPanelState`、`CameraPanelState` 構造体を追加
- `state_to_json` に `light` / `camera` フィールド追加
- Light パネル（照度値 + sparkline）、Camera パネル（解像度 + フレーム番号）を追加
- `WE_DEFS` に BH1750、DHT22、SSD1306、ESP32-CAM を追加

## テスト実行方法

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo run -p device-dashboard-web
# http://127.0.0.1:7878 でダッシュボードを確認
# → Light パネルに BH1750 照度、Camera パネルに ESP32-CAM フレーム番号が表示される
# → Wiring Editor サイドバーに BH1750/DHT22/SSD1306/ESP32-CAM が追加されている
```

## 関連 Issue

- 新センサ実装（BH1750, DHT22, SSD1306, ESP32-CAM）の追加
