### PR TITLE
feat: add BH1750, SSD1306, DHT22 adapters to platform-esp32

### DIFF
--- a/crates/platform-esp32/bh1750.rs
+++ b/crates/platform-esp32/bh1750.rs
@@ -1,0 +1,3 @@
+//! ESP32 re-export of the board-agnostic BH1750 light sensor driver.
+
+pub use reference_drivers::bh1750::*;

--- a/crates/platform-esp32/dht22.rs
+++ b/crates/platform-esp32/dht22.rs
@@ -1,0 +1,169 @@
+//! ESP32 向け DHT22 センサアダプタ。
+//!
+//! DHT22 は単線双方向プロトコル（single-wire）のため、正確な bit 読み取りには
+//! マイクロ秒精度の GPIO timing が必要です。このモジュールでは:
+//!
+//! - `reference_drivers::dht22::Dht22RawDevice` トレイトと `Dht22Sensor<DEV>` を re-export
+//! - `Esp32Dht22RawDevice<P, D>` を提供（`embedded-hal` v1.0 対応 InputPin+OutputPin と
+//!   `DelayNs` から 40 ビット raw データを読み取るスケルトン実装）
+//!
+//! # 注意
+//!
+//! `bit_read_impl` は現在スタブです。実際の esp-idf 実装では
+//! `esp_idf_svc::hal::gpio::PinDriver` の開放コレクタ設定と
+//! `esp_idf_svc::hal::delay::FreeRtos` を組み合わせて使用してください。
+
+pub use reference_drivers::dht22::{Dht22RawDevice, Dht22Sensor};
+
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{InputPin, OutputPin},
+};
+use hal_api::error::SensorError;
+
+/// ESP32 向け DHT22 raw ビット読み取り実装。
+///
+/// `P` には開放コレクタ設定の GPIO ピン（入出力兼用）を想定しています。
+/// 実 HAL では `PinDriver` をそのまま渡せます。
+///
+/// # 型パラメータ
+///
+/// * `P` — 入出力兼用ピン（`embedded-hal` v1.0 `InputPin + OutputPin`）
+/// * `D` — マイクロ秒精度の delay 実装（`embedded-hal` v1.0 `DelayNs`）
+pub struct Esp32Dht22RawDevice<P, D> {
+    pin: P,
+    delay: D,
+}
+
+impl<P, D> Esp32Dht22RawDevice<P, D>
+where
+    P: InputPin + OutputPin,
+    D: DelayNs,
+{
+    /// ピンと delay から `Esp32Dht22RawDevice` を生成します。
+    pub fn new(pin: P, delay: D) -> Self {
+        Self { pin, delay }
+    }
+
+    /// 内部のピン参照を取得します。
+    pub fn pin(&self) -> &P {
+        &self.pin
+    }
+
+    /// 内部の delay 参照を取得します。
+    pub fn delay(&self) -> &D {
+        &self.delay
+    }
+}
+
+impl<P, D> Dht22RawDevice for Esp32Dht22RawDevice<P, D>
+where
+    P: InputPin + OutputPin,
+    D: DelayNs,
+{
+    type Error = SensorError;
+
+    /// DHT22 から 40 ビット（5 バイト）の raw データを読み取ります。
+    ///
+    /// # 実装状況
+    ///
+    /// 現在はスタブです。実際の esp-idf 環境向け実装では:
+    ///
+    /// 1. ホスト開始信号: LOW 18ms → HIGH 20-40µs
+    /// 2. センサ応答待機: HIGH → LOW 80µs → HIGH 80µs
+    /// 3. 40 ビット読み取り: 各ビットは LOW 50µs + HIGH (26-28µs=0 / 70µs=1)
+    fn read_raw_bytes(&mut self) -> Result<[u8; 5], SensorError> {
+        // ホスト開始信号
+        self.pin.set_low().map_err(|_| SensorError::BusError)?;
+        self.delay.delay_ms(18);
+        self.pin.set_high().map_err(|_| SensorError::BusError)?;
+        self.delay.delay_us(40);
+
+        // TODO: センサ応答確認と 40 ビット読み取り
+        // 実 HAL では下記のループで bit timing を計測する:
+        //   for bit_pos in 0..40 { ... }
+        // 現段階ではスタブとして NotInitialized を返す。
+        // esp-idf 環境で実装する際にこのブロックを置き換えてください。
+        Err(SensorError::NotInitialized)
+    }
+}
+
+/// `Esp32Dht22RawDevice<P, D>` を `Dht22Sensor` でラップした完全型エイリアス。
+pub type Esp32Dht22Sensor<P, D> = Dht22Sensor<Esp32Dht22RawDevice<P, D>>;
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use embedded_hal::digital::{Error as DigitalError, ErrorKind, ErrorType};
+
+    // ---- テスト用スタブ ----
+
+    #[derive(Debug)]
+    struct StubError;
+
+    impl DigitalError for StubError {
+        fn kind(&self) -> ErrorKind {
+            ErrorKind::Other
+        }
+    }
+
+    struct StubPin {
+        is_high: bool,
+    }
+
+    impl ErrorType for StubPin {
+        type Error = StubError;
+    }
+
+    impl InputPin for StubPin {
+        fn is_high(&mut self) -> Result<bool, StubError> {
+            Ok(self.is_high)
+        }
+
+        fn is_low(&mut self) -> Result<bool, StubError> {
+            Ok(!self.is_high)
+        }
+    }
+
+    impl OutputPin for StubPin {
+        fn set_high(&mut self) -> Result<(), StubError> {
+            self.is_high = true;
+            Ok(())
+        }
+
+        fn set_low(&mut self) -> Result<(), StubError> {
+            self.is_high = false;
+            Ok(())
+        }
+    }
+
+    struct NoopDelay;
+
+    impl embedded_hal::delay::DelayNs for NoopDelay {
+        fn delay_ns(&mut self, _ns: u32) {}
+    }
+
+    // ---- テスト ----
+
+    #[test]
+    fn esp32_dht22_raw_returns_not_initialized_stub() {
+        let pin = StubPin { is_high: true };
+        let mut dev = Esp32Dht22RawDevice::new(pin, NoopDelay);
+        let result = dev.read_raw_bytes();
+        // スタブは NotInitialized を返すことを確認
+        assert!(matches!(result, Err(SensorError::NotInitialized)));
+    }
+
+    #[test]
+    fn esp32_dht22_sensor_wraps_raw_device() {
+        let pin = StubPin { is_high: true };
+        let dev = Esp32Dht22RawDevice::new(pin, NoopDelay);
+        let mut sensor = Dht22Sensor::new(dev);
+        // Dht22Sensor::read() がエラーを正しくラップすることを確認
+        let result = hal_api::sensor::EnvSensor::read(&mut sensor);
+        assert!(result.is_err());
+    }
+}

--- a/crates/platform-esp32/dht22.rs
+++ b/crates/platform-esp32/dht22.rs
@@ -73,17 +73,11 @@ where
     /// 2. センサ応答待機: HIGH → LOW 80µs → HIGH 80µs
     /// 3. 40 ビット読み取り: 各ビットは LOW 50µs + HIGH (26-28µs=0 / 70µs=1)
     fn read_raw_bytes(&mut self) -> Result<[u8; 5], SensorError> {
-        // ホスト開始信号
-        self.pin.set_low().map_err(|_| SensorError::BusError)?;
-        self.delay.delay_ms(18);
-        self.pin.set_high().map_err(|_| SensorError::BusError)?;
-        self.delay.delay_us(40);
-
-        // TODO: センサ応答確認と 40 ビット読み取り
-        // 実 HAL では下記のループで bit timing を計測する:
-        //   for bit_pos in 0..40 { ... }
-        // 現段階ではスタブとして NotInitialized を返す。
-        // esp-idf 環境で実装する際にこのブロックを置き換えてください。
+        // TODO: esp-idf 環境向け実装手順:
+        // 1. ホスト開始信号: self.pin.set_low() → delay_ms(18) → self.pin.set_high() → delay_us(40)
+        // 2. センサ応答待機: HIGH→LOW 80µs → LOW→HIGH 80µs を確認
+        // 3. 40 ビット読み取り: LOW 50µs + HIGH (26-28µs=0 / 70µs=1) × 40
+        //    esp_idf_svc::hal::gpio::PinDriver + esp_idf_svc::hal::delay::FreeRtos で実装
         Err(SensorError::NotInitialized)
     }
 }
@@ -164,6 +158,6 @@ mod tests {
         let mut sensor = Dht22Sensor::new(dev);
         // Dht22Sensor::read() がエラーを正しくラップすることを確認
         let result = hal_api::sensor::EnvSensor::read(&mut sensor);
-        assert!(result.is_err());
+        assert!(matches!(result, Err(SensorError::NotInitialized)));
     }
 }

--- a/crates/platform-esp32/lib.rs
+++ b/crates/platform-esp32/lib.rs
@@ -10,8 +10,10 @@
 //! board 非依存 driver 本体は `reference-drivers` crate にあり、
 //! この crate では original ESP32 向けの参照経路として re-export します。
 
+pub mod bh1750;
 pub mod bme280;
 pub mod delay;
+pub mod dht22;
 pub mod gpio;
 pub mod hc_sr04;
 pub mod i2c;
@@ -21,5 +23,6 @@ pub mod mpu6050;
 pub mod pwm;
 pub mod servo;
 pub mod shared_i2c;
+pub mod ssd1306;
 
 pub use delay::Esp32Delay;

--- a/crates/platform-esp32/ssd1306.rs
+++ b/crates/platform-esp32/ssd1306.rs
@@ -1,0 +1,3 @@
+//! ESP32 re-export of the board-agnostic SSD1306 OLED display driver.
+
+pub use reference_drivers::ssd1306::*;

--- a/crates/platform-esp32/tests/new_sensor_bridge.rs
+++ b/crates/platform-esp32/tests/new_sensor_bridge.rs
@@ -1,0 +1,140 @@
+//! ESP32 Bridge tests: BH1750 light sensor と SSD1306 OLED display の
+//! platform-esp32 経由での動作を検証します。
+
+use core::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+use hal_api::error::I2cError;
+use hal_api::i2c::I2cBus;
+use hal_api::light::LightSensor;
+use platform_esp32::bh1750::{Bh1750Sensor, BH1750_ADDRESS_LOW};
+use platform_esp32::ssd1306::{Ssd1306Display, SSD1306_ADDRESS_DEFAULT};
+
+// ---- Stub I2C ----
+
+type WriteLog = Rc<RefCell<Vec<(u8, Vec<u8>)>>>;
+
+#[derive(Clone, Default)]
+struct StubI2c {
+    writes: WriteLog,
+    next_read: Rc<RefCell<Vec<u8>>>,
+}
+
+impl StubI2c {
+    fn set_next_read(&self, bytes: &[u8]) {
+        *self.next_read.borrow_mut() = bytes.to_vec();
+    }
+}
+
+impl I2cBus for StubI2c {
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, data: &[u8]) -> Result<(), I2cError> {
+        self.writes.borrow_mut().push((addr, data.to_vec()));
+        Ok(())
+    }
+
+    fn read(&mut self, _addr: u8, buf: &mut [u8]) -> Result<(), I2cError> {
+        let src = self.next_read.borrow();
+        for (dst, src) in buf.iter_mut().zip(src.iter()) {
+            *dst = *src;
+        }
+        Ok(())
+    }
+
+    fn write_read(&mut self, addr: u8, write: &[u8], buf: &mut [u8]) -> Result<(), I2cError> {
+        self.writes.borrow_mut().push((addr, write.to_vec()));
+        let src = self.next_read.borrow();
+        for (dst, src) in buf.iter_mut().zip(src.iter()) {
+            *dst = *src;
+        }
+        Ok(())
+    }
+}
+
+// ---- BH1750 bridge test ----
+
+#[test]
+fn bh1750_bridge_reads_lux_via_esp32_module() {
+    let bus = StubI2c::default();
+
+    // raw = 720 → lux×100 = 720 * 500 / 6 = 60000 (600 lx)
+    bus.set_next_read(&[0x02, 0xD0]); // 720 in big-endian
+
+    let mut sensor = Bh1750Sensor::new(bus, BH1750_ADDRESS_LOW).unwrap();
+    let reading = sensor.read_lux().unwrap();
+    assert_eq!(reading.lux_x100, 60000);
+}
+
+#[test]
+fn bh1750_bridge_uses_correct_i2c_address() {
+    assert_eq!(BH1750_ADDRESS_LOW, 0x23);
+}
+
+// ---- SSD1306 bridge test ----
+
+#[test]
+fn ssd1306_bridge_initializes_via_esp32_module() {
+    let bus = StubI2c::default();
+    let result = Ssd1306Display::new(bus, SSD1306_ADDRESS_DEFAULT);
+    assert!(result.is_ok(), "SSD1306 should initialize without error");
+}
+
+#[test]
+fn ssd1306_bridge_uses_correct_i2c_address() {
+    assert_eq!(SSD1306_ADDRESS_DEFAULT, 0x3C);
+}
+
+#[test]
+fn ssd1306_bridge_renders_frame() {
+    use hal_api::display::{TextDisplay16x2, TextFrame16x2};
+    let bus = StubI2c::default();
+    let mut display = Ssd1306Display::new(bus, SSD1306_ADDRESS_DEFAULT).unwrap();
+    let frame = TextFrame16x2::from_lines("BH1750  600 lx  ", "SSD1306 ready   ");
+    assert!(display.render(&frame).is_ok());
+}
+
+// ---- DHT22 bridge test ----
+
+#[test]
+fn dht22_bridge_stub_returns_not_initialized() {
+    use embedded_hal::digital::ErrorType;
+    use platform_esp32::dht22::Esp32Dht22RawDevice;
+
+    struct StubPin;
+
+    impl ErrorType for StubPin {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal::digital::InputPin for StubPin {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
+            Ok(false)
+        }
+    }
+
+    impl embedded_hal::digital::OutputPin for StubPin {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    struct NoopDelay;
+    impl embedded_hal::delay::DelayNs for NoopDelay {
+        fn delay_ns(&mut self, _ns: u32) {}
+    }
+
+    let mut dev = Esp32Dht22RawDevice::new(StubPin, NoopDelay);
+    let result = platform_esp32::dht22::Dht22RawDevice::read_raw_bytes(&mut dev);
+    assert!(matches!(
+        result,
+        Err(hal_api::error::SensorError::NotInitialized)
+    ));
+}

--- a/crates/platform-esp32/tests/new_sensor_bridge.rs
+++ b/crates/platform-esp32/tests/new_sensor_bridge.rs
@@ -72,6 +72,12 @@ fn bh1750_bridge_uses_correct_i2c_address() {
     assert_eq!(BH1750_ADDRESS_LOW, 0x23);
 }
 
+#[test]
+fn bh1750_bridge_uses_correct_i2c_address_high() {
+    use platform_esp32::bh1750::BH1750_ADDRESS_HIGH;
+    assert_eq!(BH1750_ADDRESS_HIGH, 0x5C);
+}
+
 // ---- SSD1306 bridge test ----
 
 #[test]
@@ -84,6 +90,12 @@ fn ssd1306_bridge_initializes_via_esp32_module() {
 #[test]
 fn ssd1306_bridge_uses_correct_i2c_address() {
     assert_eq!(SSD1306_ADDRESS_DEFAULT, 0x3C);
+}
+
+#[test]
+fn ssd1306_bridge_uses_correct_i2c_address_alt() {
+    use platform_esp32::ssd1306::SSD1306_ADDRESS_ALT;
+    assert_eq!(SSD1306_ADDRESS_ALT, 0x3D);
 }
 
 #[test]
@@ -133,6 +145,45 @@ fn dht22_bridge_stub_returns_not_initialized() {
 
     let mut dev = Esp32Dht22RawDevice::new(StubPin, NoopDelay);
     let result = platform_esp32::dht22::Dht22RawDevice::read_raw_bytes(&mut dev);
+    assert!(matches!(
+        result,
+        Err(hal_api::error::SensorError::NotInitialized)
+    ));
+}
+
+#[test]
+fn dht22_bridge_sensor_alias_stubs_correctly() {
+    use embedded_hal::digital::ErrorType;
+    use platform_esp32::dht22::{Esp32Dht22RawDevice, Esp32Dht22Sensor};
+
+    struct StubPin;
+    impl ErrorType for StubPin {
+        type Error = core::convert::Infallible;
+    }
+    impl embedded_hal::digital::InputPin for StubPin {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
+            Ok(false)
+        }
+    }
+    impl embedded_hal::digital::OutputPin for StubPin {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+    struct NoopDelay;
+    impl embedded_hal::delay::DelayNs for NoopDelay {
+        fn delay_ns(&mut self, _ns: u32) {}
+    }
+
+    let dev = Esp32Dht22RawDevice::new(StubPin, NoopDelay);
+    let mut sensor: Esp32Dht22Sensor<_, _> = Esp32Dht22Sensor::new(dev);
+    let result = hal_api::sensor::EnvSensor::read(&mut sensor);
     assert!(matches!(
         result,
         Err(hal_api::error::SensorError::NotInitialized)


### PR DESCRIPTION
## 概要

PR #70-71 で reference-drivers に追加した BH1750・SSD1306・DHT22 ドライバを
platform-esp32 から使えるようにします。sim-to-real 経路の完成に必要な最終ピースです。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `platform-esp32/bh1750.rs` | `reference_drivers::bh1750` の re-export |
| `platform-esp32/ssd1306.rs` | `reference_drivers::ssd1306` の re-export |
| `platform-esp32/dht22.rs` | `Esp32Dht22RawDevice<P,D>` スケルトン + `Dht22Sensor` re-export |
| `platform-esp32/lib.rs` | 3モジュールを pub mod に追加 |
| `platform-esp32/tests/new_sensor_bridge.rs` | 6 件の bridge テスト |

### DHT22 について

DHT22 はシングルワイヤープロトコルのため、µs 精度の GPIO timing が必要です。
`Esp32Dht22RawDevice` は `Dht22RawDevice` トレイトを実装するスタブで、
現段階では `SensorError::NotInitialized` を返します。
実際の esp-idf 実装では `read_raw_bytes()` 内のコメントに従って
ビット読み取りループを実装してください。

## テスト実行

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
```

Closes #73