### PR TITLE
feat: add ESP32-C3 cross-check CI job and dev-loop.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,12 @@ jobs:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.toml') }}
 
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
+
       - name: Check hal-api for ESP32-C3
         run: cargo check -p hal-api --lib --target $ESP32C3_TARGET
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   NO_STD_TARGET: thumbv6m-none-eabi
+  ESP32C3_TARGET: riscv32imc-unknown-none-elf
 
 jobs:
   test:
@@ -159,3 +160,39 @@ jobs:
 
       - name: Check platform-avr for no_std target
         run: cargo check -p platform-avr --lib --target $NO_STD_TARGET
+
+  esp32c3:
+    name: ESP32-C3 Cross Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain with ESP32-C3 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.ESP32C3_TARGET }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Check hal-api for ESP32-C3
+        run: cargo check -p hal-api --lib --target $ESP32C3_TARGET
+
+      - name: Check core-app for ESP32-C3
+        run: cargo check -p core-app --lib --target $ESP32C3_TARGET
+
+      - name: Check reference-drivers for ESP32-C3
+        run: cargo check -p reference-drivers --lib --target $ESP32C3_TARGET
+
+      - name: Check platform-esp32 for ESP32-C3
+        run: cargo check -p platform-esp32 --lib --target $ESP32C3_TARGET

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,7 +91,70 @@ gh auth login
 
 ---
 
-## 🔧 推奨ワークフロー
+### `dev-loop.sh` - シミュレータ / ESP32 デプロイループ
+
+PC シミュレータの起動・ESP32 実機へのフラッシュ・クロスビルドチェックを一コマンドで実行します。
+
+**基本的な使用方法:**
+
+```bash
+# PCシミュレータを起動
+./scripts/dev-loop.sh sim
+
+# 全CIチェック + ESP32-C3クロスビルドを実行
+./scripts/dev-loop.sh check
+
+# ESP32実機へフラッシュ
+ESP32_PORT=/dev/cu.usbserial-0001 ./scripts/dev-loop.sh flash
+
+# フラッシュ後にシリアルモニタを開く
+ESP32_PORT=/dev/cu.usbserial-0001 ./scripts/dev-loop.sh monitor
+```
+
+**環境変数:**
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `ESP32_PORT` | ESP32 のシリアルポート | `/dev/cu.usbserial-0001`（macOS）<br>`/dev/ttyUSB0`（Linux） |
+
+**シリアルポートの調べ方:**
+
+```bash
+# macOS
+ls /dev/cu.usbserial-*
+
+# Linux
+ls /dev/ttyUSB*
+
+# または
+dmesg | tail -5  # デバイス接続直後
+```
+
+**WSL2 の場合:**
+
+Windows 側の `espflash.exe` を使うことを推奨します。WSL2 からの USB デバイス直アクセスは usbipd が必要です。
+
+**espflash のインストール（flash/monitor に必要）:**
+
+```bash
+cargo install espflash
+```
+
+---
+
+### sim-to-real 開発サイクル
+
+```bash
+# 1. PCシミュレータでロジックを確認
+./scripts/dev-loop.sh sim
+# → http://127.0.0.1:7878 でダッシュボードを確認
+
+# 2. ESP32-C3 クロスビルドが壊れていないか確認
+./scripts/dev-loop.sh check
+
+# 3. 実機へフラッシュ（espflash が必要）
+ESP32_PORT=/dev/cu.usbserial-0001 ./scripts/dev-loop.sh monitor
+```
 
 ### PRを作成する前
 
@@ -132,7 +195,11 @@ rustup component add clippy
 ### `no_std` ターゲットが見つからない
 
 ```bash
+# ARM Cortex-M0 (Arduino, AVR 互換)
 rustup target add thumbv6m-none-eabi
+
+# ESP32-C3 (RISC-V)
+rustup target add riscv32imc-unknown-none-elf
 ```
 
 ### `gh` コマンドが見つからない

--- a/scripts/dev-loop.sh
+++ b/scripts/dev-loop.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# dev-loop.sh — シミュレータ / ESP32 フラッシュ / クロスビルドチェック
+#
+# 使用方法:
+#   ./scripts/dev-loop.sh sim        PCシミュレータを起動
+#   ./scripts/dev-loop.sh check      全CIチェック + ESP32-C3クロスビルドを実行
+#   ./scripts/dev-loop.sh flash      ESP32実機へフラッシュ（espflash が必要）
+#   ./scripts/dev-loop.sh monitor    フラッシュ後にシリアルモニタを開く
+#
+# 依存ツール:
+#   sim/check: Rust stable toolchain + riscv32imc-unknown-none-elf target
+#   flash/monitor: espflash (cargo install espflash)
+#
+# シリアルポートの例:
+#   macOS/Linux: /dev/cu.usbserial-* または /dev/ttyUSB0
+#   WSL2 + Windows: espflash.exe をフルパスで指定する代替経路を使用
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ESP32C3_TARGET="riscv32imc-unknown-none-elf"
+FIRMWARE_CRATE="platform-esp32"
+DASHBOARD_CRATE="device-dashboard-web"
+SERIAL_PORT="${ESP32_PORT:-}"
+
+log_step() { echo -e "${BLUE}==>${NC} $1"; }
+log_ok()   { echo -e "${GREEN}✓${NC} $1"; }
+log_warn() { echo -e "${YELLOW}⚠${NC}  $1"; }
+log_err()  { echo -e "${RED}✗${NC}  $1"; }
+
+usage() {
+  echo "Usage: $0 {sim|check|flash|monitor}"
+  echo ""
+  echo "  sim      PCシミュレータを起動 (http://127.0.0.1:7878)"
+  echo "  check    CIチェック + ESP32-C3クロスビルドを実行"
+  echo "  flash    ESP32実機へフラッシュ"
+  echo "  monitor  フラッシュ後にシリアルモニタを開く"
+  echo ""
+  echo "環境変数:"
+  echo "  ESP32_PORT    シリアルポート (例: /dev/cu.usbserial-0001, /dev/ttyUSB0)"
+  exit 1
+}
+
+cmd_sim() {
+  log_step "PCシミュレータを起動します..."
+  log_step "ダッシュボード: http://127.0.0.1:7878"
+  echo ""
+  cargo run -p "$DASHBOARD_CRATE"
+}
+
+cmd_check() {
+  log_step "1/5 テストを実行..."
+  cargo test --workspace --all-targets
+  log_ok "テスト完了"
+
+  log_step "2/5 フォーマットチェック..."
+  cargo fmt --all -- --check
+  log_ok "フォーマット OK"
+
+  log_step "3/5 Clippy..."
+  cargo clippy --workspace --all-targets -- -D warnings
+  log_ok "Clippy OK"
+
+  log_step "4/5 no_std チェック (thumbv6m-none-eabi)..."
+  for crate in hal-api core-app reference-drivers platform-esp32 platform-avr; do
+    cargo check -p "$crate" --lib --target thumbv6m-none-eabi
+  done
+  log_ok "no_std OK"
+
+  log_step "5/5 ESP32-C3 クロスビルドチェック (${ESP32C3_TARGET})..."
+  if ! rustup target list --installed | grep -q "$ESP32C3_TARGET"; then
+    log_warn "ターゲット ${ESP32C3_TARGET} が未インストールです。追加します..."
+    rustup target add "$ESP32C3_TARGET"
+  fi
+  for crate in hal-api core-app reference-drivers platform-esp32; do
+    cargo check -p "$crate" --lib --target "$ESP32C3_TARGET"
+    log_ok "  $crate: OK"
+  done
+
+  echo ""
+  log_ok "全チェック完了！PR 作成準備 OK"
+}
+
+cmd_flash() {
+  if ! command -v espflash &>/dev/null; then
+    log_err "espflash が見つかりません。インストールしてください:"
+    echo "  cargo install espflash"
+    exit 1
+  fi
+
+  if [[ -z "$SERIAL_PORT" ]]; then
+    log_warn "ESP32_PORT が未設定です。自動検出を試みます..."
+    DETECTED=$(ls /dev/cu.usbserial-* /dev/ttyUSB* 2>/dev/null | head -1 || true)
+    if [[ -z "$DETECTED" ]]; then
+      log_err "シリアルポートが見つかりません。"
+      echo "  macOS/Linux: ESP32_PORT=/dev/cu.usbserial-XXXX $0 flash"
+      echo "  WSL2:        espflash.exe を使用してください"
+      exit 1
+    fi
+    SERIAL_PORT="$DETECTED"
+    log_step "検出: $SERIAL_PORT"
+  fi
+
+  log_step "ESP32-C3 向けリリースビルド..."
+  cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"
+
+  log_step "フラッシュ書き込み: $SERIAL_PORT"
+  espflash flash \
+    --port "$SERIAL_PORT" \
+    "target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
+  log_ok "フラッシュ完了"
+}
+
+cmd_monitor() {
+  if ! command -v espflash &>/dev/null; then
+    log_err "espflash が見つかりません: cargo install espflash"
+    exit 1
+  fi
+
+  if [[ -z "$SERIAL_PORT" ]]; then
+    DETECTED=$(ls /dev/cu.usbserial-* /dev/ttyUSB* 2>/dev/null | head -1 || true)
+    SERIAL_PORT="${DETECTED:-}"
+  fi
+
+  if [[ -z "$SERIAL_PORT" ]]; then
+    log_err "ESP32_PORT が未設定です。"
+    echo "  ESP32_PORT=/dev/cu.usbserial-XXXX $0 monitor"
+    exit 1
+  fi
+
+  log_step "フラッシュ + モニタ: $SERIAL_PORT"
+  cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"
+  espflash flash \
+    --port "$SERIAL_PORT" \
+    --monitor \
+    "target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
+}
+
+case "${1:-}" in
+  sim)     cmd_sim ;;
+  check)   cmd_check ;;
+  flash)   cmd_flash ;;
+  monitor) cmd_monitor ;;
+  *)       usage ;;
+esac

--- a/scripts/dev-loop.sh
+++ b/scripts/dev-loop.sh
@@ -12,6 +12,11 @@
 #   sim/check: Rust stable toolchain + riscv32imc-unknown-none-elf target
 #   flash/monitor: espflash (cargo install espflash)
 #
+# 環境変数:
+#   ESP32_PORT      シリアルポート (例: /dev/cu.usbserial-0001, /dev/ttyUSB0)
+#   FIRMWARE_CRATE  フラッシュ対象クレート名（[[bin]] を持つクレートが必要）
+#                   デフォルト: platform-esp32 (ライブラリのみ — 実際のファームウェアに変更してください)
+#
 # シリアルポートの例:
 #   macOS/Linux: /dev/cu.usbserial-* または /dev/ttyUSB0
 #   WSL2 + Windows: espflash.exe をフルパスで指定する代替経路を使用
@@ -25,8 +30,8 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 ESP32C3_TARGET="riscv32imc-unknown-none-elf"
-FIRMWARE_CRATE="platform-esp32"
-DASHBOARD_CRATE="device-dashboard-web"
+FIRMWARE_CRATE="${FIRMWARE_CRATE:-platform-esp32}"
+DASHBOARD_CRATE="platform-pc-sim"
 SERIAL_PORT="${ESP32_PORT:-}"
 
 log_step() { echo -e "${BLUE}==>${NC} $1"; }
@@ -51,7 +56,7 @@ cmd_sim() {
   log_step "PCシミュレータを起動します..."
   log_step "ダッシュボード: http://127.0.0.1:7878"
   echo ""
-  cargo run -p "$DASHBOARD_CRATE"
+  cargo run -p "$DASHBOARD_CRATE" --bin device-dashboard-web
 }
 
 cmd_check() {
@@ -108,12 +113,23 @@ cmd_flash() {
   fi
 
   log_step "ESP32-C3 向けリリースビルド..."
-  cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"
+  BINARY_PATH="target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
+  if ! cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"; then
+    log_err "ビルドに失敗しました。'${FIRMWARE_CRATE}' に [[bin]] エントリーが必要です。"
+    echo "  例: FIRMWARE_CRATE=your-esp32c3-firmware $0 flash"
+    exit 1
+  fi
+  if [[ ! -f "$BINARY_PATH" ]]; then
+    log_err "バイナリが見つかりません: ${BINARY_PATH}"
+    echo "  '${FIRMWARE_CRATE}' は [[bin]] を持つクレートである必要があります。"
+    echo "  例: FIRMWARE_CRATE=your-esp32c3-firmware $0 flash"
+    exit 1
+  fi
 
   log_step "フラッシュ書き込み: $SERIAL_PORT"
   espflash flash \
     --port "$SERIAL_PORT" \
-    "target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
+    "$BINARY_PATH"
   log_ok "フラッシュ完了"
 }
 
@@ -126,6 +142,7 @@ cmd_monitor() {
   if [[ -z "$SERIAL_PORT" ]]; then
     DETECTED=$(ls /dev/cu.usbserial-* /dev/ttyUSB* 2>/dev/null | head -1 || true)
     SERIAL_PORT="${DETECTED:-}"
+    [[ -n "$SERIAL_PORT" ]] && log_step "検出: $SERIAL_PORT"
   fi
 
   if [[ -z "$SERIAL_PORT" ]]; then
@@ -134,12 +151,23 @@ cmd_monitor() {
     exit 1
   fi
 
+  BINARY_PATH="target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
   log_step "フラッシュ + モニタ: $SERIAL_PORT"
-  cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"
+  if ! cargo build -p "$FIRMWARE_CRATE" --release --target "$ESP32C3_TARGET"; then
+    log_err "ビルドに失敗しました。FIRMWARE_CRATE=${FIRMWARE_CRATE}"
+    echo "  例: FIRMWARE_CRATE=your-esp32c3-firmware $0 monitor"
+    exit 1
+  fi
+  if [[ ! -f "$BINARY_PATH" ]]; then
+    log_err "バイナリが見つかりません: ${BINARY_PATH}"
+    echo "  例: FIRMWARE_CRATE=your-esp32c3-firmware $0 monitor"
+    exit 1
+  fi
   espflash flash \
     --port "$SERIAL_PORT" \
     --monitor \
-    "target/${ESP32C3_TARGET}/release/${FIRMWARE_CRATE}"
+    "$BINARY_PATH"
+  log_ok "モニタ終了"
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## 概要

ESP32-C3（RISC-V）向けのクロスビルドチェック CI ジョブと、sim-to-real 開発ループスクリプトを追加しました。

## 変更内容

### CI（`.github/workflows/ci.yml`）

新ジョブ `esp32c3` を追加:
- ターゲット: `riscv32imc-unknown-none-elf`（ESP32-C3 の RISC-V アーキテクチャ）
- 対象クレート: `hal-api` / `core-app` / `reference-drivers` / `platform-esp32`
- これにより ESP32-C3 向けビルド破壊を PR マージ前に検知できます

### スクリプト（`scripts/dev-loop.sh`）

sim-to-real 開発ループを4コマンドに統一:

| コマンド | 機能 |
|---------|------|
| `sim` | PCシミュレータを起動（http://127.0.0.1:7878） |
| `check` | 全CIチェック + ESP32-C3クロスビルドを実行 |
| `flash` | ESP32実機へフラッシュ（espflash 必要） |
| `monitor` | フラッシュ後にシリアルモニタを開く |

シリアルポート自動検出（`/dev/cu.usbserial-*` / `/dev/ttyUSB*`）。macOS / Linux を前提とし、WSL2 は代替経路として案内。

### ドキュメント（`scripts/README.md`）

- `dev-loop.sh` の説明と使用例を追加
- sim-to-real 開発サイクルの推奨フローを追加
- `riscv32imc-unknown-none-elf` のインストール方法をトラブルシューティングに追加

## テスト方法

```bash
# ESP32-C3 クロスビルドチェック
cargo check -p platform-esp32 --lib --target riscv32imc-unknown-none-elf

# スクリプト構文チェック
bash -n scripts/dev-loop.sh

# シミュレータ起動確認
./scripts/dev-loop.sh sim
```

## 関連 Issue

Closes #39
