### PR TITLE
feat: expand wiring config to all 8 simulation devices

### DIFF
--- a/crates/platform-pc-sim/dashboard.rs
+++ b/crates/platform-pc-sim/dashboard.rs
@@ -124,7 +124,7 @@ impl BoardProfile {
     pub fn cam_pin(self) -> &'static str {
         match self {
             Self::OriginalEsp32 => "GPIO0",
-            Self::ArduinoNano => "D13",
+            Self::ArduinoNano => "N/A",
         }
     }
 }

--- a/crates/platform-pc-sim/dashboard.rs
+++ b/crates/platform-pc-sim/dashboard.rs
@@ -119,6 +119,14 @@ impl BoardProfile {
             Self::ArduinoNano => "D11",
         }
     }
+
+    /// GPIO pin used as boot/programming pin for the camera module.
+    pub fn cam_pin(self) -> &'static str {
+        match self {
+            Self::OriginalEsp32 => "GPIO0",
+            Self::ArduinoNano => "D13",
+        }
+    }
 }
 
 pub struct DashboardSnapshot<'a> {

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -235,6 +235,7 @@ mod tests {
         assert_eq!(cfg.echo_pin, "D3");
         assert_eq!(cfg.servo_pin, "D9");
         assert_eq!(cfg.motor_pin, "D5");
+        assert_eq!(cfg.cam_pin, "N/A");
     }
 
     #[test]
@@ -256,9 +257,23 @@ mod tests {
     #[test]
     fn wiring_config_devices_have_correct_connection_types() {
         let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
-        assert_eq!(cfg.devices[3].kind.connection_type(), ConnectionType::I2c);
-        assert_eq!(cfg.devices[5].kind.connection_type(), ConnectionType::Pwm);
-        assert_eq!(cfg.devices[7].kind.connection_type(), ConnectionType::Gpio);
+        let expected = [
+            ConnectionType::I2c,  // [0] BME280
+            ConnectionType::I2c,  // [1] MPU6050
+            ConnectionType::I2c,  // [2] LCD1602
+            ConnectionType::I2c,  // [3] BH1750
+            ConnectionType::Pwm,  // [4] Servo
+            ConnectionType::Pwm,  // [5] L298N
+            ConnectionType::Gpio, // [6] HC-SR04
+            ConnectionType::Gpio, // [7] ESP32-CAM
+        ];
+        for (i, exp) in expected.iter().enumerate() {
+            assert_eq!(
+                cfg.devices[i].kind.connection_type(),
+                *exp,
+                "device[{i}] has wrong connection type"
+            );
+        }
     }
 
     #[test]

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -70,15 +70,14 @@ impl DeviceSpec {
     }
 
     pub fn gpio(kind: DeviceKind) -> Self {
-        let label = kind.label().to_string();
-        Self {
-            kind,
-            address: None,
-            label,
-        }
+        Self::non_i2c(kind)
     }
 
     pub fn pwm(kind: DeviceKind) -> Self {
+        Self::non_i2c(kind)
+    }
+
+    fn non_i2c(kind: DeviceKind) -> Self {
         let label = kind.label().to_string();
         Self {
             kind,
@@ -98,9 +97,11 @@ pub struct WiringConfig {
     pub ground_pin: String,
     pub trig_pin: String,
     pub echo_pin: String,
-    pub servo_pin: String,
     /// Representative pin for the camera module (GPIO0 / boot pin on ESP32).
     pub cam_pin: String,
+    pub servo_pin: String,
+    /// L298N motor driver enable-A pin (ENA).
+    pub motor_pin: String,
     pub devices: Vec<DeviceSpec>,
 }
 
@@ -109,17 +110,17 @@ impl WiringConfig {
     ///
     /// Returns the full simulator configuration matching `DeviceSimulationRig`:
     /// BME280 (0x77), MPU6050 (0x68), LCD1602 (0x27), BH1750 (0x23) on I²C;
-    /// HC-SR04 and ESP32-CAM on GPIO; Servo and L298N on PWM.
+    /// Servo and L298N on PWM; HC-SR04 and ESP32-CAM on GPIO.
     pub fn from_board(board: BoardProfile) -> Self {
         let devices = vec![
             DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
             DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
             DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
             DeviceSpec::i2c(DeviceKind::Bh1750, 0x23),
-            DeviceSpec::gpio(DeviceKind::HcSr04),
-            DeviceSpec::gpio(DeviceKind::Esp32Cam),
             DeviceSpec::pwm(DeviceKind::Servo),
             DeviceSpec::pwm(DeviceKind::L298n),
+            DeviceSpec::gpio(DeviceKind::HcSr04),
+            DeviceSpec::gpio(DeviceKind::Esp32Cam),
         ];
         Self {
             sda_pin: board.sda_pin().to_string(),
@@ -128,8 +129,9 @@ impl WiringConfig {
             ground_pin: "GND".to_string(),
             trig_pin: board.trig_pin().to_string(),
             echo_pin: board.echo_pin().to_string(),
-            servo_pin: board.servo_pwm_pin().to_string(),
             cam_pin: board.cam_pin().to_string(),
+            servo_pin: board.servo_pwm_pin().to_string(),
+            motor_pin: board.motor_ena_pin().to_string(),
             board,
             devices,
         }
@@ -168,7 +170,8 @@ impl WiringConfig {
             concat!(
                 r#"{{"board":"{board}","sda_pin":"{sda}","scl_pin":"{scl}","#,
                 r#""power_pin":"{vcc}","ground_pin":"{gnd}","#,
-                r#""trig_pin":"{trig}","echo_pin":"{echo}","servo_pin":"{sv}","cam_pin":"{cam}","#,
+                r#""trig_pin":"{trig}","echo_pin":"{echo}","cam_pin":"{cam}","#,
+                r#""servo_pin":"{sv}","motor_pin":"{mot}","#,
                 r#""devices":[{devs}]}}"#
             ),
             board = board_str,
@@ -178,8 +181,9 @@ impl WiringConfig {
             gnd = json_escape(&self.ground_pin),
             trig = json_escape(&self.trig_pin),
             echo = json_escape(&self.echo_pin),
-            sv = json_escape(&self.servo_pin),
             cam = json_escape(&self.cam_pin),
+            sv = json_escape(&self.servo_pin),
+            mot = json_escape(&self.motor_pin),
             devs = devices.join(","),
         )
     }
@@ -215,7 +219,10 @@ mod tests {
         assert_eq!(cfg.scl_pin, "GPIO22");
         assert_eq!(cfg.power_pin, "3V3");
         assert_eq!(cfg.trig_pin, "GPIO5");
+        assert_eq!(cfg.echo_pin, "GPIO18");
         assert_eq!(cfg.servo_pin, "GPIO13");
+        assert_eq!(cfg.motor_pin, "GPIO25");
+        assert_eq!(cfg.cam_pin, "GPIO0");
     }
 
     #[test]
@@ -227,6 +234,7 @@ mod tests {
         assert_eq!(cfg.trig_pin, "D2");
         assert_eq!(cfg.echo_pin, "D3");
         assert_eq!(cfg.servo_pin, "D9");
+        assert_eq!(cfg.motor_pin, "D5");
     }
 
     #[test]
@@ -234,11 +242,23 @@ mod tests {
         let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
         assert_eq!(cfg.devices.len(), 8);
         assert_eq!(cfg.devices[0].kind, DeviceKind::Bme280);
-        assert_eq!(cfg.devices[4].kind, DeviceKind::HcSr04);
-        assert_eq!(cfg.devices[4].kind.connection_type(), ConnectionType::Gpio);
-        assert_eq!(cfg.devices[6].kind, DeviceKind::Servo);
-        assert_eq!(cfg.devices[6].kind.connection_type(), ConnectionType::Pwm);
-        assert_eq!(cfg.devices[7].kind, DeviceKind::L298n);
+        assert_eq!(cfg.devices[3].kind, DeviceKind::Bh1750);
+        // order: I2C(0-3) → PWM(4-5) → GPIO(6-7)
+        assert_eq!(cfg.devices[4].kind, DeviceKind::Servo);
+        assert_eq!(cfg.devices[4].kind.connection_type(), ConnectionType::Pwm);
+        assert_eq!(cfg.devices[5].kind, DeviceKind::L298n);
+        assert_eq!(cfg.devices[5].kind.connection_type(), ConnectionType::Pwm);
+        assert_eq!(cfg.devices[6].kind, DeviceKind::HcSr04);
+        assert_eq!(cfg.devices[6].kind.connection_type(), ConnectionType::Gpio);
+        assert_eq!(cfg.devices[7].kind, DeviceKind::Esp32Cam);
+    }
+
+    #[test]
+    fn wiring_config_devices_have_correct_connection_types() {
+        let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        assert_eq!(cfg.devices[3].kind.connection_type(), ConnectionType::I2c);
+        assert_eq!(cfg.devices[5].kind.connection_type(), ConnectionType::Pwm);
+        assert_eq!(cfg.devices[7].kind.connection_type(), ConnectionType::Gpio);
     }
 
     #[test]
@@ -253,5 +273,6 @@ mod tests {
         assert!(json.contains(r#""kind":"l298n""#));
         assert!(json.contains(r#""kind":"esp32_cam""#));
         assert!(json.contains(r#""cam_pin":"GPIO0""#));
+        assert!(json.contains(r#""motor_pin":"GPIO25""#));
     }
 }

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -12,6 +12,10 @@ pub enum DeviceKind {
     Mpu6050,
     Lcd1602,
     HcSr04,
+    Bh1750,
+    Servo,
+    L298n,
+    Esp32Cam,
 }
 
 impl DeviceKind {
@@ -21,12 +25,17 @@ impl DeviceKind {
             DeviceKind::Mpu6050 => "MPU6050",
             DeviceKind::Lcd1602 => "LCD1602",
             DeviceKind::HcSr04 => "HC-SR04",
+            DeviceKind::Bh1750 => "BH1750",
+            DeviceKind::Servo => "Servo",
+            DeviceKind::L298n => "L298N",
+            DeviceKind::Esp32Cam => "ESP32-CAM",
         }
     }
 
     pub fn connection_type(&self) -> ConnectionType {
         match self {
-            DeviceKind::HcSr04 => ConnectionType::Gpio,
+            DeviceKind::HcSr04 | DeviceKind::Esp32Cam => ConnectionType::Gpio,
+            DeviceKind::Servo | DeviceKind::L298n => ConnectionType::Pwm,
             _ => ConnectionType::I2c,
         }
     }
@@ -37,6 +46,8 @@ impl DeviceKind {
 pub enum ConnectionType {
     I2c,
     Gpio,
+    /// PWM signal (Servo, motor driver enable pins).
+    Pwm,
 }
 
 /// Specification of a single device in the wiring config.
@@ -66,6 +77,15 @@ impl DeviceSpec {
             label,
         }
     }
+
+    pub fn pwm(kind: DeviceKind) -> Self {
+        let label = kind.label().to_string();
+        Self {
+            kind,
+            address: None,
+            label,
+        }
+    }
 }
 
 /// Full wiring description for the board + all attached devices.
@@ -79,22 +99,27 @@ pub struct WiringConfig {
     pub trig_pin: String,
     pub echo_pin: String,
     pub servo_pin: String,
+    /// Representative pin for the camera module (GPIO0 / boot pin on ESP32).
+    pub cam_pin: String,
     pub devices: Vec<DeviceSpec>,
 }
 
 impl WiringConfig {
     /// Build the standard wiring config for a board profile.
     ///
-    /// Returns a fixed simulator configuration: BME280 (0x77), MPU6050 (0x68),
-    /// LCD1602 (0x27) on I²C, and HC-SR04 on GPIO.  All four devices are always
-    /// present regardless of the profile; this matches the `DeviceSimulationRig`
-    /// setup used by the PC simulator.
+    /// Returns the full simulator configuration matching `DeviceSimulationRig`:
+    /// BME280 (0x77), MPU6050 (0x68), LCD1602 (0x27), BH1750 (0x23) on I²C;
+    /// HC-SR04 and ESP32-CAM on GPIO; Servo and L298N on PWM.
     pub fn from_board(board: BoardProfile) -> Self {
         let devices = vec![
             DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
             DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
             DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
+            DeviceSpec::i2c(DeviceKind::Bh1750, 0x23),
             DeviceSpec::gpio(DeviceKind::HcSr04),
+            DeviceSpec::gpio(DeviceKind::Esp32Cam),
+            DeviceSpec::pwm(DeviceKind::Servo),
+            DeviceSpec::pwm(DeviceKind::L298n),
         ];
         Self {
             sda_pin: board.sda_pin().to_string(),
@@ -104,6 +129,7 @@ impl WiringConfig {
             trig_pin: board.trig_pin().to_string(),
             echo_pin: board.echo_pin().to_string(),
             servo_pin: board.servo_pwm_pin().to_string(),
+            cam_pin: board.cam_pin().to_string(),
             board,
             devices,
         }
@@ -124,6 +150,10 @@ impl WiringConfig {
                     DeviceKind::Mpu6050 => "mpu6050",
                     DeviceKind::Lcd1602 => "lcd1602",
                     DeviceKind::HcSr04 => "hc_sr04",
+                    DeviceKind::Bh1750 => "bh1750",
+                    DeviceKind::Servo => "servo",
+                    DeviceKind::L298n => "l298n",
+                    DeviceKind::Esp32Cam => "esp32_cam",
                 };
                 match d.address {
                     Some(a) => format!(
@@ -138,7 +168,7 @@ impl WiringConfig {
             concat!(
                 r#"{{"board":"{board}","sda_pin":"{sda}","scl_pin":"{scl}","#,
                 r#""power_pin":"{vcc}","ground_pin":"{gnd}","#,
-                r#""trig_pin":"{trig}","echo_pin":"{echo}","servo_pin":"{sv}","#,
+                r#""trig_pin":"{trig}","echo_pin":"{echo}","servo_pin":"{sv}","cam_pin":"{cam}","#,
                 r#""devices":[{devs}]}}"#
             ),
             board = board_str,
@@ -149,6 +179,7 @@ impl WiringConfig {
             trig = json_escape(&self.trig_pin),
             echo = json_escape(&self.echo_pin),
             sv = json_escape(&self.servo_pin),
+            cam = json_escape(&self.cam_pin),
             devs = devices.join(","),
         )
     }
@@ -199,12 +230,15 @@ mod tests {
     }
 
     #[test]
-    fn wiring_config_has_four_devices() {
+    fn wiring_config_has_eight_devices() {
         let cfg = WiringConfig::from_board(BoardProfile::OriginalEsp32);
-        assert_eq!(cfg.devices.len(), 4);
+        assert_eq!(cfg.devices.len(), 8);
         assert_eq!(cfg.devices[0].kind, DeviceKind::Bme280);
-        assert_eq!(cfg.devices[3].kind, DeviceKind::HcSr04);
-        assert_eq!(cfg.devices[3].kind.connection_type(), ConnectionType::Gpio);
+        assert_eq!(cfg.devices[4].kind, DeviceKind::HcSr04);
+        assert_eq!(cfg.devices[4].kind.connection_type(), ConnectionType::Gpio);
+        assert_eq!(cfg.devices[6].kind, DeviceKind::Servo);
+        assert_eq!(cfg.devices[6].kind.connection_type(), ConnectionType::Pwm);
+        assert_eq!(cfg.devices[7].kind, DeviceKind::L298n);
     }
 
     #[test]
@@ -214,5 +248,10 @@ mod tests {
         assert!(json.contains(r#""sda_pin":"GPIO21""#));
         assert!(json.contains(r#""address":"0x77""#));
         assert!(json.contains(r#""kind":"hc_sr04""#));
+        assert!(json.contains(r#""kind":"bh1750""#));
+        assert!(json.contains(r#""kind":"servo""#));
+        assert!(json.contains(r#""kind":"l298n""#));
+        assert!(json.contains(r#""kind":"esp32_cam""#));
+        assert!(json.contains(r#""cam_pin":"GPIO0""#));
     }
 }

--- a/crates/platform-pc-sim/wiring_svg.rs
+++ b/crates/platform-pc-sim/wiring_svg.rs
@@ -32,8 +32,10 @@ const P_SDA: i32 = BOARD_Y + 52;
 const P_SCL: i32 = BOARD_Y + 96;
 const P_VCC: i32 = BOARD_Y + 152;
 const P_GND: i32 = BOARD_Y + 200;
-/// PWM pin (Servo / motor driver enable) — aligned with SRV label row.
+/// PWM pin (Servo) — aligned with SRV label row.
 const P_PWM: i32 = BOARD_Y + 263;
+/// PWM pin (L298N motor driver enable) — aligned with MOT label row.
+const P_MOT: i32 = BOARD_Y + 277;
 /// GPIO pin (HC-SR04 trigger / camera boot).
 const P_GPIO: i32 = BOARD_Y + 355;
 
@@ -90,7 +92,8 @@ fn render(out: &mut String, config: &WiringConfig) {
         (P_SCL, "dot-scl", format!("SCL/{}", config.scl_pin)),
         (P_VCC, "dot-vcc", config.power_pin.clone()),
         (P_GND, "dot-gnd", config.ground_pin.clone()),
-        (P_PWM, "dot-pwm", format!("PWM/{}", config.servo_pin)),
+        (P_PWM, "dot-pwm", format!("SRV/{}", config.servo_pin)),
+        (P_MOT, "dot-pwm", format!("MOT/{}", config.motor_pin)),
         (P_GPIO, "dot-gpio", format!("GPIO/{}", config.trig_pin)),
     ] {
         let _ = write!(
@@ -226,14 +229,14 @@ fn render(out: &mut String, config: &WiringConfig) {
                 );
             }
             ConnectionType::Pwm => {
-                let pwm_pin = if dev.kind == DeviceKind::L298n {
-                    &config.motor_pin
+                let (origin_y, pwm_pin) = if dev.kind == DeviceKind::L298n {
+                    (P_MOT, &config.motor_pin)
                 } else {
-                    &config.servo_pin
+                    (P_PWM, &config.servo_pin)
                 };
                 let _ = write!(
                     out,
-                    r#"<path class="w-pwm" d="M {BOARD_R} {P_PWM} C {cp} {P_PWM} {cp} {mid_y} {DEV_X} {mid_y}"/>
+                    r#"<path class="w-pwm" d="M {BOARD_R} {origin_y} C {cp} {origin_y} {cp} {mid_y} {DEV_X} {mid_y}"/>
 <circle cx="{DEV_X}" cy="{mid_y}" r="3" class="dot-pwm"/>
 <text x="{}" y="{}" class="dev-sub">PWM:{pwm_pin}</text>
 "#,
@@ -292,6 +295,7 @@ mod tests {
         assert!(svg.contains("GPIO22"), "missing SCL pin");
         assert!(svg.contains("3V3"), "missing power pin");
         assert!(svg.contains("GPIO13"), "missing servo PWM pin");
+        assert!(svg.contains("GPIO25"), "missing motor ENA pin");
         assert!(svg.contains("GPIO0"), "missing cam pin");
     }
 

--- a/crates/platform-pc-sim/wiring_svg.rs
+++ b/crates/platform-pc-sim/wiring_svg.rs
@@ -10,19 +10,19 @@ use crate::wiring_config::{ConnectionType, WiringConfig};
 
 /// Generate a self-contained SVG string for the given wiring config.
 pub fn wiring_svg(config: &WiringConfig) -> String {
-    let mut buf = String::with_capacity(8192);
+    let mut buf = String::with_capacity(12288);
     render(&mut buf, config);
     buf
 }
 
 // ── layout constants ────────────────────────────────────────────────────────
-const W: i32 = 560;
-const H: i32 = 380;
+const W: i32 = 580;
+const H: i32 = 520;
 
 const BOARD_X: i32 = 16;
 const BOARD_Y: i32 = 44;
 const BOARD_W: i32 = 104;
-const BOARD_H: i32 = 292;
+const BOARD_H: i32 = 420;
 
 // Board right edge (where pin dots sit)
 const BOARD_R: i32 = BOARD_X + BOARD_W; // 120
@@ -32,14 +32,16 @@ const P_SDA: i32 = BOARD_Y + 52;
 const P_SCL: i32 = BOARD_Y + 96;
 const P_VCC: i32 = BOARD_Y + 152;
 const P_GND: i32 = BOARD_Y + 200;
-/// Midpoint between TRIG (gpio_y+8) and ECHO (gpio_y+22) label rows.
-const P_GPIO: i32 = BOARD_Y + 255;
+/// PWM pin (Servo / motor driver enable).
+const P_PWM: i32 = BOARD_Y + 278;
+/// GPIO pin (HC-SR04 trigger / camera boot).
+const P_GPIO: i32 = BOARD_Y + 355;
 
 // Devices
-const DEV_X: i32 = 382;
-const DEV_W: i32 = 148;
-const DEV_H: i32 = 52;
-const DEV_GAP: i32 = 14;
+const DEV_X: i32 = 390;
+const DEV_W: i32 = 160;
+const DEV_H: i32 = 42;
+const DEV_GAP: i32 = 10;
 
 #[allow(clippy::write_with_newline)]
 fn render(out: &mut String, config: &WiringConfig) {
@@ -60,8 +62,9 @@ fn render(out: &mut String, config: &WiringConfig) {
 .w-vcc{{fill:none;stroke:#e55;stroke-width:1.6}}
 .w-gnd{{fill:none;stroke:#556;stroke-width:1.6}}
 .w-gpio{{fill:none;stroke:#ff9944;stroke-width:1.8;stroke-dasharray:6 3;animation:wiring-flow 2s linear infinite}}
+.w-pwm{{fill:none;stroke:#bb88ff;stroke-width:1.8;stroke-dasharray:6 3;animation:wiring-flow 1.5s linear infinite}}
 @keyframes wiring-flow{{from{{stroke-dashoffset:24}}to{{stroke-dashoffset:0}}}}
-.dot-sda{{fill:#4488ff}}.dot-scl{{fill:#ffdd44}}.dot-vcc{{fill:#e55}}.dot-gnd{{fill:#556}}.dot-gpio{{fill:#ff9944}}
+.dot-sda{{fill:#4488ff}}.dot-scl{{fill:#ffdd44}}.dot-vcc{{fill:#e55}}.dot-gnd{{fill:#556}}.dot-gpio{{fill:#ff9944}}.dot-pwm{{fill:#bb88ff}}
 .leg{{fill:#888;font:9px monospace}}
 </style></defs>
 "#
@@ -87,6 +90,7 @@ fn render(out: &mut String, config: &WiringConfig) {
         (P_SCL, "dot-scl", format!("SCL/{}", config.scl_pin)),
         (P_VCC, "dot-vcc", config.power_pin.clone()),
         (P_GND, "dot-gnd", config.ground_pin.clone()),
+        (P_PWM, "dot-pwm", format!("PWM/{}", config.servo_pin)),
         (P_GPIO, "dot-gpio", format!("GPIO/{}", config.trig_pin)),
     ] {
         let _ = write!(
@@ -99,14 +103,14 @@ fn render(out: &mut String, config: &WiringConfig) {
         );
     }
 
-    // Additional GPIO pins label block
-    let gpio_y = BOARD_Y + 240;
+    // GPIO pin group label block
+    let gpio_y = BOARD_Y + 330;
     let _ = write!(
         out,
         r#"<text x="{}" y="{}" class="pcb-sub" text-anchor="middle">GPIO</text>
 <text x="{}" y="{}" class="pcb-pin" text-anchor="end">TRIG/{}</text>
 <text x="{}" y="{}" class="pcb-pin" text-anchor="end">ECHO/{}</text>
-<text x="{}" y="{}" class="pcb-pin" text-anchor="end">PWM/{}</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">CAM/{}</text>
 "#,
         cx,
         gpio_y - 6,
@@ -118,6 +122,24 @@ fn render(out: &mut String, config: &WiringConfig) {
         config.echo_pin,
         BOARD_R - 7,
         gpio_y + 36,
+        config.cam_pin,
+    );
+
+    // PWM pin group label block
+    let pwm_y = BOARD_Y + 255;
+    let _ = write!(
+        out,
+        r#"<text x="{}" y="{}" class="pcb-sub" text-anchor="middle">PWM</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">SRV/{}</text>
+<text x="{}" y="{}" class="pcb-pin" text-anchor="end">MOT/{}</text>
+"#,
+        cx,
+        pwm_y - 6,
+        BOARD_R - 7,
+        pwm_y + 8,
+        config.servo_pin,
+        BOARD_R - 7,
+        pwm_y + 22,
         config.servo_pin,
     );
 
@@ -141,7 +163,7 @@ fn render(out: &mut String, config: &WiringConfig) {
 <text x="{}" y="{}" class="dev-lbl">{}</text>
 "#,
             DEV_X + 8,
-            dy + 17,
+            dy + 15,
             dev.kind.label(),
         );
         if let Some(addr) = dev.address {
@@ -150,12 +172,12 @@ fn render(out: &mut String, config: &WiringConfig) {
                 r#"<text x="{}" y="{}" class="dev-sub">I²C addr: 0x{addr:02X}</text>
 "#,
                 DEV_X + 8,
-                dy + 31,
+                dy + 28,
             );
         }
 
         // VCC wire
-        let y_vcc = dy + 9;
+        let y_vcc = dy + 8;
         let _ = write!(
             out,
             r#"<path class="w-vcc" d="M {BOARD_R} {P_VCC} C {cp} {P_VCC} {cp} {y_vcc} {DEV_X} {y_vcc}"/>
@@ -163,7 +185,7 @@ fn render(out: &mut String, config: &WiringConfig) {
         );
 
         // GND wire
-        let y_gnd = dy + DEV_H - 9;
+        let y_gnd = dy + DEV_H - 8;
         let _ = write!(
             out,
             r#"<path class="w-gnd" d="M {BOARD_R} {P_GND} C {cp} {P_GND} {cp} {y_gnd} {DEV_X} {y_gnd}"/>
@@ -172,8 +194,8 @@ fn render(out: &mut String, config: &WiringConfig) {
 
         match conn {
             ConnectionType::I2c => {
-                let y_sda = mid_y - 7;
-                let y_scl = mid_y + 5;
+                let y_sda = mid_y - 6;
+                let y_scl = mid_y + 4;
                 let _ = write!(
                     out,
                     r#"<path class="w-sda" d="M {BOARD_R} {P_SDA} C {cp} {P_SDA} {cp} {y_sda} {DEV_X} {y_sda}"/>
@@ -184,27 +206,45 @@ fn render(out: &mut String, config: &WiringConfig) {
                 );
             }
             ConnectionType::Gpio => {
-                // HC-SR04: wire from GPIO pin dot to device midpoint
                 let trig_pin = &config.trig_pin;
                 let echo_pin = &config.echo_pin;
+                let cam_pin = &config.cam_pin;
+                let is_camera = dev.kind == crate::wiring_config::DeviceKind::Esp32Cam;
+                let pin_label = if is_camera {
+                    format!("GPIO:{cam_pin}")
+                } else {
+                    format!("TRIG:{trig_pin} / ECHO:{echo_pin}")
+                };
                 let _ = write!(
                     out,
                     r#"<path class="w-gpio" d="M {BOARD_R} {P_GPIO} C {cp} {P_GPIO} {cp} {mid_y} {DEV_X} {mid_y}"/>
 <circle cx="{DEV_X}" cy="{mid_y}" r="3" class="dot-gpio"/>
-<text x="{}" y="{}" class="dev-sub">TRIG:{trig_pin} / ECHO:{echo_pin}</text>
+<text x="{}" y="{}" class="dev-sub">{pin_label}</text>
 "#,
                     DEV_X + 8,
-                    dy + 44,
+                    dy + DEV_H - 4,
+                );
+            }
+            ConnectionType::Pwm => {
+                let servo_pin = &config.servo_pin;
+                let _ = write!(
+                    out,
+                    r#"<path class="w-pwm" d="M {BOARD_R} {P_PWM} C {cp} {P_PWM} {cp} {mid_y} {DEV_X} {mid_y}"/>
+<circle cx="{DEV_X}" cy="{mid_y}" r="3" class="dot-pwm"/>
+<text x="{}" y="{}" class="dev-sub">PWM:{servo_pin}</text>
+"#,
+                    DEV_X + 8,
+                    dy + DEV_H - 4,
                 );
             }
         }
     }
 
-    // Legend at bottom — use CSS classes to avoid "# in raw string
+    // Legend at bottom
     let leg_y = H - 10;
     let _ = write!(
         out,
-        r#"<text x="{}" y="{leg_y}" class="leg" text-anchor="middle"><tspan class="dot-sda">━━</tspan> SDA <tspan dx="8" class="dot-scl">━━</tspan> SCL <tspan dx="8" class="dot-vcc">━━</tspan> VCC <tspan dx="8" class="dot-gnd">━━</tspan> GND <tspan dx="8" class="dot-gpio">━━</tspan> GPIO</text>
+        r#"<text x="{}" y="{leg_y}" class="leg" text-anchor="middle"><tspan class="dot-sda">━━</tspan> SDA <tspan dx="6" class="dot-scl">━━</tspan> SCL <tspan dx="6" class="dot-vcc">━━</tspan> VCC <tspan dx="6" class="dot-gnd">━━</tspan> GND <tspan dx="6" class="dot-gpio">━━</tspan> GPIO <tspan dx="6" class="dot-pwm">━━</tspan> PWM</text>
 "#,
         W / 2,
     );
@@ -234,6 +274,10 @@ mod tests {
         assert!(svg.contains("MPU6050"));
         assert!(svg.contains("LCD1602"));
         assert!(svg.contains("HC-SR04"));
+        assert!(svg.contains("BH1750"));
+        assert!(svg.contains("Servo"));
+        assert!(svg.contains("L298N"));
+        assert!(svg.contains("ESP32-CAM"));
     }
 
     #[test]
@@ -243,6 +287,8 @@ mod tests {
         assert!(svg.contains("GPIO21"), "missing SDA pin");
         assert!(svg.contains("GPIO22"), "missing SCL pin");
         assert!(svg.contains("3V3"), "missing power pin");
+        assert!(svg.contains("GPIO13"), "missing servo PWM pin");
+        assert!(svg.contains("GPIO0"), "missing cam pin");
     }
 
     #[test]
@@ -253,6 +299,7 @@ mod tests {
         assert!(svg.contains("stroke-dasharray"), "missing dash array");
         assert!(svg.contains("w-sda"), "missing SDA wire class");
         assert!(svg.contains("w-scl"), "missing SCL wire class");
+        assert!(svg.contains("w-pwm"), "missing PWM wire class");
     }
 
     #[test]

--- a/crates/platform-pc-sim/wiring_svg.rs
+++ b/crates/platform-pc-sim/wiring_svg.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Write as _;
 
-use crate::wiring_config::{ConnectionType, WiringConfig};
+use crate::wiring_config::{ConnectionType, DeviceKind, WiringConfig};
 
 /// Generate a self-contained SVG string for the given wiring config.
 pub fn wiring_svg(config: &WiringConfig) -> String {
@@ -32,8 +32,8 @@ const P_SDA: i32 = BOARD_Y + 52;
 const P_SCL: i32 = BOARD_Y + 96;
 const P_VCC: i32 = BOARD_Y + 152;
 const P_GND: i32 = BOARD_Y + 200;
-/// PWM pin (Servo / motor driver enable).
-const P_PWM: i32 = BOARD_Y + 278;
+/// PWM pin (Servo / motor driver enable) — aligned with SRV label row.
+const P_PWM: i32 = BOARD_Y + 263;
 /// GPIO pin (HC-SR04 trigger / camera boot).
 const P_GPIO: i32 = BOARD_Y + 355;
 
@@ -140,7 +140,7 @@ fn render(out: &mut String, config: &WiringConfig) {
         config.servo_pin,
         BOARD_R - 7,
         pwm_y + 22,
-        config.servo_pin,
+        config.motor_pin,
     );
 
     // Devices
@@ -226,12 +226,16 @@ fn render(out: &mut String, config: &WiringConfig) {
                 );
             }
             ConnectionType::Pwm => {
-                let servo_pin = &config.servo_pin;
+                let pwm_pin = if dev.kind == DeviceKind::L298n {
+                    &config.motor_pin
+                } else {
+                    &config.servo_pin
+                };
                 let _ = write!(
                     out,
                     r#"<path class="w-pwm" d="M {BOARD_R} {P_PWM} C {cp} {P_PWM} {cp} {mid_y} {DEV_X} {mid_y}"/>
 <circle cx="{DEV_X}" cy="{mid_y}" r="3" class="dot-pwm"/>
-<text x="{}" y="{}" class="dev-sub">PWM:{servo_pin}</text>
+<text x="{}" y="{}" class="dev-sub">PWM:{pwm_pin}</text>
 "#,
                     DEV_X + 8,
                     dy + DEV_H - 4,


### PR DESCRIPTION
## 概要
配線図（Wiring SVG）に、シミュレーター上で動作する全 8 デバイスを表示するよう拡張します。

## 変更前 / 変更後
- 表示デバイス: 4 種 → 8 種（BME280, MPU6050, LCD1602, HC-SR04 + BH1750, Servo, L298N, ESP32-CAM）
- 接続タイプ: I2C / GPIO → I2C / GPIO / PWM（紫色ワイヤー追加）

## 変更ファイル
- wiring_config.rs: DeviceKind に 4 variant 追加、ConnectionType::Pwm 追加、cam_pin フィールド、from_board() を 8 デバイスに拡張
- wiring_svg.rs: キャンバス 560x380 → 580x520、PWM ピン行、w-pwm CSS 追加
- dashboard.rs: BoardProfile::cam_pin() メソッド追加

## テスト
cargo test --workspace --all-targets (41 tests pass)
cargo clippy --workspace --all-targets -- -D warnings (clean)

Closes #78