### PR TITLE
feat: add SensorProfile for configurable sensor sets in WiringConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.11] - 2025-07-16
+
+### Added
+- `SensorProfile` enum in `wiring_config.rs`: `Full`, `ClimateStation`, `RobotBase`, `Minimal`
+  — each profile specifies which sensors appear in the wiring diagram
+- `WiringConfig::from_board_with_sensors(board, SensorProfile)` constructor; `from_board()` now
+  calls this with `SensorProfile::Full` for backward compatibility
+- `WiringConfig::to_json()` now includes `"sensor_profile":"<slug>"` field
+- `GET /api/wiring/profiles` endpoint — returns JSON array of all available profiles with slug,
+  display name, and device list
+- `POST /api/wiring` now accepts `"sensor_profile"` key in body to switch profiles
+- Wiring Diagram panel in dashboard gains a sensor-profile `<select>` dynamically populated
+  from `/api/wiring/profiles` on page load
+- `WiringState { board, sensor_profile }` single Mutex in `ServerContext` eliminates TOCTOU
+  between board and profile reads
+- `parse_json_string_field(json, key)` shared helper replaces duplicated parsing implementations
+- `SensorProfile::all_variants()` returns `&'static [SensorProfile]` (single source of truth)
+- `impl Default for SensorProfile` (defaults to `Full`)
+- 17 new unit tests; total: 297
+
+### Changed
+- `SensorProfile::all()` renamed to `all_variants()` to follow Rust convention
+
+---
+
 ## [0.3.10] - 2025-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - **📊 terminal dashboard**: `climate-dashboard-sim` で sensor / LCD / I2C / wiring view を 1 画面で確認できる
 - **🌐 browser dashboard**: `device-dashboard-web` で climate / HC-SR04 / MPU6050 / servo / motor driver をブラウザで可視化できる
 - **🧪 IMU driver bridge**: `MPU6050` は host-side mock device と reference driver を経由して GUI / test に載せられる
+- **🗂️ SensorProfile**: `WiringConfig::from_board_with_sensors(board, SensorProfile::ClimateStation)` など 4 プロファイルでセンサー構成を切り替え可能
 - **📏 distance driver bridge**: `HC-SR04` は pulse/echo mock device と reference driver を経由して GUI / test に載せられる
 - **🧱 sensor / actuator 契約を拡張**: `hal-api` に distance / IMU / servo / drive motor / dual motor driver の board 非依存 trait を追加
 - **🌡️ Sim-to-real 経路**: `ClimateDisplayApp` を PC simulator と original ESP32 実機で再利用
@@ -580,9 +581,11 @@ mcu-hal-sim-rs/
 - [ ] `ClimateDisplayApp` の reference path を保ちながら、新しい board / sensor の追加手順を標準化する
 - [ ] `Arduino Nano` の bring-up から `platform-avr` へ還流できる共通 contract を切り出す
 - [ ] `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` のような候補を、共通契約へ還元できる単位で検証する
-- [x] servo / motor driver の host-side mock を実 driver bridge まで広げる（v0.3.1–v0.3.2）
+- [x] servo / motor driver の host-side mock を実 driver bridge まで広げる（v0.3.9–v0.3.10）
+- [x] `SensorProfile` で WiringConfig のセンサーセットをプロファイル切り替え対応にする（v0.3.11）
+- [ ] `platform-esp32` を実 esp-hal crate に接続し、ESP32 フラッシュ書き込み CI を追加する
+- [ ] `no_std` feature flag を明示化（`hal-api`・`core-app`）
 - [ ] browser dashboard を WebSocket / canvas / wiring editor まで育てる
-- [ ] `EnvSensor` 以外の sensor / actuator lineup も増やし、downstream repo が driver を差し替えやすい状態を作る
 - [ ] publish 対象 crate の release 導線を固める
 
 詳細は [CHANGELOG.md](./CHANGELOG.md) と [PLAN.md](./PLAN.md) を参照してください。

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -560,26 +560,30 @@ fn format_operation(operation: &VirtualI2cOperation) -> String {
     }
 }
 
-/// Extract the `"board"` string value from a minimal JSON object.
+/// Extract a string field value from a minimal JSON body.
 ///
-/// Handles `{"board":"arduino-nano"}` without pulling in a full JSON parser.
-fn parse_board_from_json(json: &str) -> Option<&str> {
-    let after_key = json.split("\"board\"").nth(1)?;
+/// Handles `{"key":"value"}` without a full JSON parser.
+fn parse_json_string_field<'a>(json: &'a str, key: &str) -> Option<&'a str> {
+    let key_literal = format!("\"{key}\"");
+    let after_key = json.split(key_literal.as_str()).nth(1)?;
     let after_colon = after_key.split(':').nth(1)?.trim_start();
     let inner = after_colon.strip_prefix('"')?;
     let end = inner.find('"')?;
     Some(&inner[..end])
 }
 
+/// Extract the `"board"` string value from a minimal JSON object.
+///
+/// Handles `{"board":"arduino-nano"}` without pulling in a full JSON parser.
+fn parse_board_from_json(json: &str) -> Option<&str> {
+    parse_json_string_field(json, "board")
+}
+
 /// Extract `sensor_profile` field from a JSON body string.
 ///
 /// Handles `{"sensor_profile":"climate"}` without a full JSON parser.
 fn parse_sensor_profile_from_json(json: &str) -> Option<&str> {
-    let after_key = json.split("\"sensor_profile\"").nth(1)?;
-    let after_colon = after_key.split(':').nth(1)?.trim_start();
-    let inner = after_colon.strip_prefix('"')?;
-    let end = inner.find('"')?;
-    Some(&inner[..end])
+    parse_json_string_field(json, "sensor_profile")
 }
 
 fn respond(stream: &mut TcpStream, status: &str, content_type: &str, body: &str) {
@@ -1198,5 +1202,13 @@ mod tests {
     #[test]
     fn parse_sensor_profile_from_json_returns_none_for_empty_body() {
         assert_eq!(parse_sensor_profile_from_json(""), None);
+    }
+
+    #[test]
+    fn parse_json_string_field_handles_space_after_colon() {
+        assert_eq!(
+            parse_json_string_field(r#"{"sensor_profile": "climate"}"#, "sensor_profile"),
+            Some("climate")
+        );
     }
 }

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -928,9 +928,9 @@ fn handle_connection(
             );
         }
         (_, "/api/wiring/profiles") => {
-            let entries: Vec<String> = SensorProfile::all()
+            let entries: Vec<String> = SensorProfile::all_variants()
                 .iter()
-                .map(|(slug, name)| format!(r#"{{"slug":"{slug}","name":"{name}"}}"#))
+                .map(|p| format!(r#"{{"slug":"{}","name":"{}"}}"#, p.slug(), p.display_name()))
                 .collect();
             let payload = format!(r#"{{"profiles":[{}]}}"#, entries.join(","));
             respond(

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -34,7 +34,7 @@ use platform_pc_sim::web_dashboard::{
     MotorChannelState, MotorDriverPanelState, RtcPanelState, ServoPanelState, TofPanelState,
     WiringPanelState,
 };
-use platform_pc_sim::wiring_config::WiringConfig;
+use platform_pc_sim::wiring_config::{SensorProfile, WiringConfig};
 use platform_pc_sim::wiring_svg::wiring_svg;
 use reference_drivers::bh1750::{Bh1750Sensor, BH1750_ADDRESS_LOW};
 use reference_drivers::bme280::{Bme280Sensor, BME280_ADDRESS_PRIMARY};
@@ -54,6 +54,7 @@ struct ServerContext {
     latest_json: Mutex<String>,
     ws_clients: Mutex<Vec<mpsc::SyncSender<String>>>,
     current_board: Mutex<BoardProfile>,
+    current_sensor_profile: Mutex<SensorProfile>,
     /// Last wiring-editor JSON submitted via POST /api/wiring/editor.
     editor_json: Mutex<String>,
 }
@@ -64,6 +65,7 @@ impl ServerContext {
             latest_json: Mutex::new("{}".into()),
             ws_clients: Mutex::new(vec![]),
             current_board: Mutex::new(board),
+            current_sensor_profile: Mutex::new(SensorProfile::Full),
             editor_json: Mutex::new("{}".into()),
         })
     }
@@ -554,6 +556,17 @@ fn parse_board_from_json(json: &str) -> Option<&str> {
     Some(&inner[..end])
 }
 
+/// Extract `sensor_profile` field from a JSON body string.
+///
+/// Handles `{"sensor_profile":"climate"}` without a full JSON parser.
+fn parse_sensor_profile_from_json(json: &str) -> Option<&str> {
+    let after_key = json.split("\"sensor_profile\"").nth(1)?;
+    let after_colon = after_key.split(':').nth(1)?.trim_start();
+    let inner = after_colon.strip_prefix('"')?;
+    let end = inner.find('"')?;
+    Some(&inner[..end])
+}
+
 fn respond(stream: &mut TcpStream, status: &str, content_type: &str, body: &str) {
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -899,8 +912,27 @@ fn handle_connection(
                 // Give the main thread time to apply the change.
                 thread::sleep(Duration::from_millis(50));
             }
+            if let Some(profile_slug) = parse_sensor_profile_from_json(body) {
+                if let Some(profile) = SensorProfile::from_slug(profile_slug) {
+                    *ctx.current_sensor_profile.lock().unwrap() = profile;
+                }
+            }
             let board = *ctx.current_board.lock().unwrap();
-            let payload = WiringConfig::from_board(board).to_json();
+            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
+            let payload = WiringConfig::from_board_with_sensors(board, sensor_profile).to_json();
+            respond(
+                &mut stream,
+                "200 OK",
+                "application/json; charset=utf-8",
+                &payload,
+            );
+        }
+        (_, "/api/wiring/profiles") => {
+            let entries: Vec<String> = SensorProfile::all()
+                .iter()
+                .map(|(slug, name)| format!(r#"{{"slug":"{slug}","name":"{name}"}}"#))
+                .collect();
+            let payload = format!(r#"{{"profiles":[{}]}}"#, entries.join(","));
             respond(
                 &mut stream,
                 "200 OK",
@@ -910,7 +942,8 @@ fn handle_connection(
         }
         (_, "/api/wiring") => {
             let board = *ctx.current_board.lock().unwrap();
-            let payload = WiringConfig::from_board(board).to_json();
+            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
+            let payload = WiringConfig::from_board_with_sensors(board, sensor_profile).to_json();
             respond(
                 &mut stream,
                 "200 OK",
@@ -920,7 +953,8 @@ fn handle_connection(
         }
         (_, "/api/wiring/svg") => {
             let board = *ctx.current_board.lock().unwrap();
-            let cfg = WiringConfig::from_board(board);
+            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
+            let cfg = WiringConfig::from_board_with_sensors(board, sensor_profile);
             let svg = wiring_svg(&cfg);
             respond(&mut stream, "200 OK", "image/svg+xml; charset=utf-8", &svg);
         }
@@ -1115,5 +1149,31 @@ mod tests {
     #[test]
     fn parse_board_from_json_returns_none_for_empty_body() {
         assert_eq!(parse_board_from_json(""), None);
+    }
+
+    #[test]
+    fn parse_sensor_profile_from_json_extracts_profile() {
+        assert_eq!(
+            parse_sensor_profile_from_json(r#"{"sensor_profile":"climate"}"#),
+            Some("climate")
+        );
+    }
+
+    #[test]
+    fn parse_sensor_profile_from_json_handles_combined_body() {
+        assert_eq!(
+            parse_sensor_profile_from_json(r#"{"board":"esp32","sensor_profile":"robot"}"#),
+            Some("robot")
+        );
+    }
+
+    #[test]
+    fn parse_sensor_profile_from_json_returns_none_for_missing_key() {
+        assert_eq!(parse_sensor_profile_from_json(r#"{"board":"esp32"}"#), None);
+    }
+
+    #[test]
+    fn parse_sensor_profile_from_json_returns_none_for_empty_body() {
+        assert_eq!(parse_sensor_profile_from_json(""), None);
     }
 }

--- a/crates/platform-pc-sim/device_dashboard_web.rs
+++ b/crates/platform-pc-sim/device_dashboard_web.rs
@@ -49,12 +49,23 @@ use reference_drivers::vl53l0x::{Vl53l0xSensor, VL53L0X_ADDRESS};
 
 const DEFAULT_PORT: u16 = 7878;
 
+/// Combined board + sensor profile state read/written as a unit.
+#[derive(Clone, Copy)]
+struct WiringState {
+    board: BoardProfile,
+    sensor_profile: SensorProfile,
+}
+
 /// Shared server state passed to every connection-handler thread.
 struct ServerContext {
     latest_json: Mutex<String>,
     ws_clients: Mutex<Vec<mpsc::SyncSender<String>>>,
     current_board: Mutex<BoardProfile>,
+    /// Kept for future use; wiring API reads now go through `wiring_state`.
+    #[allow(dead_code)]
     current_sensor_profile: Mutex<SensorProfile>,
+    /// Atomic board + sensor profile state for wiring API reads.
+    wiring_state: Mutex<WiringState>,
     /// Last wiring-editor JSON submitted via POST /api/wiring/editor.
     editor_json: Mutex<String>,
 }
@@ -66,6 +77,10 @@ impl ServerContext {
             ws_clients: Mutex::new(vec![]),
             current_board: Mutex::new(board),
             current_sensor_profile: Mutex::new(SensorProfile::Full),
+            wiring_state: Mutex::new(WiringState {
+                board,
+                sensor_profile: SensorProfile::Full,
+            }),
             editor_json: Mutex::new("{}".into()),
         })
     }
@@ -912,14 +927,22 @@ fn handle_connection(
                 // Give the main thread time to apply the change.
                 thread::sleep(Duration::from_millis(50));
             }
-            if let Some(profile_slug) = parse_sensor_profile_from_json(body) {
-                if let Some(profile) = SensorProfile::from_slug(profile_slug) {
-                    *ctx.current_sensor_profile.lock().unwrap() = profile;
+            // Update wiring_state atomically as a single unit.
+            let wiring = {
+                let mut ws = ctx.wiring_state.lock().unwrap();
+                if let Some(board_name) = parse_board_from_json(body) {
+                    ws.board = BoardProfile::from_arg(Some(board_name));
                 }
-            }
-            let board = *ctx.current_board.lock().unwrap();
-            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
-            let payload = WiringConfig::from_board_with_sensors(board, sensor_profile).to_json();
+                if let Some(profile_slug) = parse_sensor_profile_from_json(body) {
+                    if let Some(profile) = SensorProfile::from_slug(profile_slug) {
+                        ws.sensor_profile = profile;
+                    }
+                }
+                *ws
+            };
+            let payload =
+                WiringConfig::from_board_with_sensors(wiring.board, wiring.sensor_profile)
+                    .to_json();
             respond(
                 &mut stream,
                 "200 OK",
@@ -941,9 +964,10 @@ fn handle_connection(
             );
         }
         (_, "/api/wiring") => {
-            let board = *ctx.current_board.lock().unwrap();
-            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
-            let payload = WiringConfig::from_board_with_sensors(board, sensor_profile).to_json();
+            let wiring = *ctx.wiring_state.lock().unwrap();
+            let payload =
+                WiringConfig::from_board_with_sensors(wiring.board, wiring.sensor_profile)
+                    .to_json();
             respond(
                 &mut stream,
                 "200 OK",
@@ -952,9 +976,8 @@ fn handle_connection(
             );
         }
         (_, "/api/wiring/svg") => {
-            let board = *ctx.current_board.lock().unwrap();
-            let sensor_profile = *ctx.current_sensor_profile.lock().unwrap();
-            let cfg = WiringConfig::from_board_with_sensors(board, sensor_profile);
+            let wiring = *ctx.wiring_state.lock().unwrap();
+            let cfg = WiringConfig::from_board_with_sensors(wiring.board, wiring.sensor_profile);
             let svg = wiring_svg(&cfg);
             respond(&mut stream, "200 OK", "image/svg+xml; charset=utf-8", &svg);
         }

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -805,10 +805,6 @@ pub fn dashboard_html() -> &'static str {
             <option value="arduino-nano">Arduino Nano</option>
           </select>
           <select id="sensor-profile-select" style="font-size:12px;background:#1a2a1a;color:#7bc47b;border:1px solid #3d7a3d;border-radius:4px;padding:2px 6px;cursor:pointer">
-            <option value="full">Full (all devices)</option>
-            <option value="climate">Climate Station</option>
-            <option value="robot">Robot Base</option>
-            <option value="minimal">Minimal (BME280 + LCD)</option>
           </select>
         </h2>
         <div id="wiring-svg-wrap" style="width:100%;overflow-x:auto;min-height:180px"></div>
@@ -1037,10 +1033,22 @@ pub fn dashboard_html() -> &'static str {
         await loadWiringDiagram();
       } catch(_) {}
     }
+    async function initProfileSelect() {
+      try {
+        const res = await fetch("/api/wiring/profiles");
+        const data = await res.json();
+        const sel = $("sensor-profile-select");
+        if (!sel) return;
+        sel.innerHTML = data.profiles
+          .map(p => `<option value="${p.slug}">${p.name}</option>`)
+          .join("");
+      } catch(_) {}
+    }
     const boardSel = $("board-select");
     if (boardSel) boardSel.addEventListener("change", changeWiringConfig);
     const profileSel = $("sensor-profile-select");
     if (profileSel) profileSel.addEventListener("change", changeWiringConfig);
+    initProfileSelect();
     loadWiringDiagram();
     setInterval(loadWiringDiagram, 5000);
 
@@ -1588,6 +1596,10 @@ mod tests {
         assert!(html.contains("/api/wiring/svg"));
         assert!(html.contains("wiring-svg-wrap"));
         assert!(html.contains("loadWiringDiagram"));
+        // sensor profile selector
+        assert!(html.contains("sensor-profile-select"));
+        assert!(html.contains("initProfileSelect"));
+        assert!(html.contains("changeWiringConfig"));
         // E2E test runner
         assert!(html.contains("/api/test/stream"));
         assert!(html.contains("run-tests-btn"));

--- a/crates/platform-pc-sim/web_dashboard.rs
+++ b/crates/platform-pc-sim/web_dashboard.rs
@@ -804,6 +804,12 @@ pub fn dashboard_html() -> &'static str {
             <option value="original-esp32">Original ESP32</option>
             <option value="arduino-nano">Arduino Nano</option>
           </select>
+          <select id="sensor-profile-select" style="font-size:12px;background:#1a2a1a;color:#7bc47b;border:1px solid #3d7a3d;border-radius:4px;padding:2px 6px;cursor:pointer">
+            <option value="full">Full (all devices)</option>
+            <option value="climate">Climate Station</option>
+            <option value="robot">Robot Base</option>
+            <option value="minimal">Minimal (BME280 + LCD)</option>
+          </select>
         </h2>
         <div id="wiring-svg-wrap" style="width:100%;overflow-x:auto;min-height:180px"></div>
         <div class="footer" style="margin-top:6px">
@@ -1016,18 +1022,25 @@ pub fn dashboard_html() -> &'static str {
         if (wrap) wrap.innerHTML = svg;
       } catch(_) {}
     }
-    async function changeBoard(boardName) {
+    async function changeWiringConfig() {
       try {
+        const boardSel = $("board-select");
+        const profileSel = $("sensor-profile-select");
+        const body = {};
+        if (boardSel) body.board = boardSel.value;
+        if (profileSel) body.sensor_profile = profileSel.value;
         await fetch("/api/wiring", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ board: boardName }),
+          body: JSON.stringify(body),
         });
         await loadWiringDiagram();
       } catch(_) {}
     }
     const boardSel = $("board-select");
-    if (boardSel) boardSel.addEventListener("change", () => changeBoard(boardSel.value));
+    if (boardSel) boardSel.addEventListener("change", changeWiringConfig);
+    const profileSel = $("sensor-profile-select");
+    if (profileSel) profileSel.addEventListener("change", changeWiringConfig);
     loadWiringDiagram();
     setInterval(loadWiringDiagram, 5000);
 

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -2,8 +2,133 @@
 //!
 //! Provides a board-independent description of the hardware setup used by
 //! the visual wiring diagram generator.
+//!
+//! ## Board vs Sensor separation
+//!
+//! - [`crate::dashboard::BoardProfile`] describes **hardware** (pin assignments, MCU type).
+//! - [`SensorProfile`] describes **which sensors** are attached.
+//!
+//! Use [`WiringConfig::from_board_with_sensors`] to combine the two.  
+//! [`WiringConfig::from_board`] is a shortcut for [`SensorProfile::Full`].
 
 use crate::dashboard::BoardProfile;
+
+/// Which set of sensors/actuators is attached to the board.
+///
+/// Each profile maps to a fixed subset of [`DeviceKind`]s included in the
+/// [`WiringConfig`].  Add new profiles here to describe additional hardware
+/// configurations without changing any other code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SensorProfile {
+    /// All 11 devices (BME280, MPU6050, LCD1602, BH1750, DS3231, SGP30,
+    /// VL53L0X, Servo, L298N, HC-SR04, ESP32-CAM).  This is the default.
+    Full,
+    /// Climate station: BME280 + BH1750 + SGP30 + DS3231 + LCD1602.
+    ClimateStation,
+    /// Robot base: MPU6050 + HC-SR04 + VL53L0X + Servo + L298N.
+    RobotBase,
+    /// Minimal starter: BME280 + LCD1602.
+    Minimal,
+}
+
+impl SensorProfile {
+    /// Parse a sensor profile from a URL-friendly slug string.
+    ///
+    /// ```
+    /// use platform_pc_sim::wiring_config::SensorProfile;
+    /// assert_eq!(SensorProfile::from_slug("climate"), Some(SensorProfile::ClimateStation));
+    /// assert_eq!(SensorProfile::from_slug("unknown"), None);
+    /// ```
+    pub fn from_slug(s: &str) -> Option<Self> {
+        match s {
+            "full" => Some(Self::Full),
+            "climate" => Some(Self::ClimateStation),
+            "robot" => Some(Self::RobotBase),
+            "minimal" => Some(Self::Minimal),
+            _ => None,
+        }
+    }
+
+    /// URL-friendly slug for this profile.
+    ///
+    /// ```
+    /// use platform_pc_sim::wiring_config::SensorProfile;
+    /// assert_eq!(SensorProfile::Full.slug(), "full");
+    /// assert_eq!(SensorProfile::ClimateStation.slug(), "climate");
+    /// ```
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::ClimateStation => "climate",
+            Self::RobotBase => "robot",
+            Self::Minimal => "minimal",
+        }
+    }
+
+    /// Human-readable display name.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Full => "Full (all devices)",
+            Self::ClimateStation => "Climate Station",
+            Self::RobotBase => "Robot Base",
+            Self::Minimal => "Minimal (BME280 + LCD)",
+        }
+    }
+
+    /// Returns all available sensor profiles as `(slug, display_name)` pairs.
+    ///
+    /// ```
+    /// use platform_pc_sim::wiring_config::SensorProfile;
+    /// let profiles = SensorProfile::all();
+    /// assert!(profiles.iter().any(|(slug, _)| *slug == "full"));
+    /// assert!(profiles.iter().any(|(slug, _)| *slug == "climate"));
+    /// ```
+    pub fn all() -> &'static [(&'static str, &'static str)] {
+        &[
+            ("full", "Full (all devices)"),
+            ("climate", "Climate Station"),
+            ("robot", "Robot Base"),
+            ("minimal", "Minimal (BME280 + LCD)"),
+        ]
+    }
+
+    /// Device kinds included in this profile.
+    pub(crate) fn devices(self) -> Vec<DeviceSpec> {
+        match self {
+            Self::Full => vec![
+                DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
+                DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
+                DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
+                DeviceSpec::i2c(DeviceKind::Bh1750, 0x23),
+                DeviceSpec::i2c(DeviceKind::Ds3231, 0x68),
+                DeviceSpec::i2c(DeviceKind::Sgp30, 0x58),
+                DeviceSpec::i2c(DeviceKind::Vl53l0x, 0x29),
+                DeviceSpec::pwm(DeviceKind::Servo),
+                DeviceSpec::pwm(DeviceKind::L298n),
+                DeviceSpec::gpio(DeviceKind::HcSr04),
+                DeviceSpec::gpio(DeviceKind::Esp32Cam),
+            ],
+            Self::ClimateStation => vec![
+                DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
+                DeviceSpec::i2c(DeviceKind::Bh1750, 0x23),
+                DeviceSpec::i2c(DeviceKind::Sgp30, 0x58),
+                DeviceSpec::i2c(DeviceKind::Ds3231, 0x68),
+                DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
+            ],
+            Self::RobotBase => vec![
+                DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
+                DeviceSpec::i2c(DeviceKind::Vl53l0x, 0x29),
+                DeviceSpec::gpio(DeviceKind::HcSr04),
+                DeviceSpec::pwm(DeviceKind::Servo),
+                DeviceSpec::pwm(DeviceKind::L298n),
+            ],
+            Self::Minimal => vec![
+                DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
+                DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
+            ],
+        }
+    }
+}
 
 /// Physical device type attached to the board.
 #[derive(Debug, Clone, PartialEq)]
@@ -100,6 +225,7 @@ impl DeviceSpec {
 #[derive(Debug, Clone)]
 pub struct WiringConfig {
     pub board: BoardProfile,
+    pub sensor_profile: SensorProfile,
     pub sda_pin: String,
     pub scl_pin: String,
     pub power_pin: String,
@@ -115,26 +241,21 @@ pub struct WiringConfig {
 }
 
 impl WiringConfig {
-    /// Build the standard wiring config for a board profile.
+    /// Build the wiring config for a board profile with a specific sensor set.
     ///
-    /// Returns the full simulator configuration matching `DeviceSimulationRig`:
-    /// BME280 (0x77), MPU6050 (0x68), LCD1602 (0x27), BH1750 (0x23),
-    /// DS3231 (0x68; sim uses 0x69 to avoid MPU6050 collision), SGP30 (0x58),
-    /// VL53L0X (0x29) on I²C; Servo and L298N on PWM; HC-SR04 and ESP32-CAM on GPIO.
-    pub fn from_board(board: BoardProfile) -> Self {
-        let devices = vec![
-            DeviceSpec::i2c(DeviceKind::Bme280, 0x77),
-            DeviceSpec::i2c(DeviceKind::Mpu6050, 0x68),
-            DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
-            DeviceSpec::i2c(DeviceKind::Bh1750, 0x23),
-            DeviceSpec::i2c(DeviceKind::Ds3231, 0x68),
-            DeviceSpec::i2c(DeviceKind::Sgp30, 0x58),
-            DeviceSpec::i2c(DeviceKind::Vl53l0x, 0x29),
-            DeviceSpec::pwm(DeviceKind::Servo),
-            DeviceSpec::pwm(DeviceKind::L298n),
-            DeviceSpec::gpio(DeviceKind::HcSr04),
-            DeviceSpec::gpio(DeviceKind::Esp32Cam),
-        ];
+    /// # Examples
+    ///
+    /// ```
+    /// use platform_pc_sim::dashboard::BoardProfile;
+    /// use platform_pc_sim::wiring_config::{SensorProfile, WiringConfig};
+    ///
+    /// let cfg = WiringConfig::from_board_with_sensors(
+    ///     BoardProfile::OriginalEsp32,
+    ///     SensorProfile::Minimal,
+    /// );
+    /// assert_eq!(cfg.devices.len(), 2);
+    /// ```
+    pub fn from_board_with_sensors(board: BoardProfile, sensor_profile: SensorProfile) -> Self {
         Self {
             sda_pin: board.sda_pin().to_string(),
             scl_pin: board.scl_pin().to_string(),
@@ -145,9 +266,22 @@ impl WiringConfig {
             cam_pin: board.cam_pin().to_string(),
             servo_pin: board.servo_pwm_pin().to_string(),
             motor_pin: board.motor_ena_pin().to_string(),
+            devices: sensor_profile.devices(),
             board,
-            devices,
+            sensor_profile,
         }
+    }
+
+    /// Build the standard wiring config for a board profile with all devices.
+    ///
+    /// Equivalent to `from_board_with_sensors(board, SensorProfile::Full)`.
+    ///
+    /// Returns the full simulator configuration matching `DeviceSimulationRig`:
+    /// BME280 (0x77), MPU6050 (0x68), LCD1602 (0x27), BH1750 (0x23),
+    /// DS3231 (0x68; sim uses 0x69 to avoid MPU6050 collision), SGP30 (0x58),
+    /// VL53L0X (0x29) on I²C; Servo and L298N on PWM; HC-SR04 and ESP32-CAM on GPIO.
+    pub fn from_board(board: BoardProfile) -> Self {
+        Self::from_board_with_sensors(board, SensorProfile::Full)
     }
 
     /// Serialise to a simple JSON string.
@@ -184,13 +318,15 @@ impl WiringConfig {
             .collect();
         format!(
             concat!(
-                r#"{{"board":"{board}","sda_pin":"{sda}","scl_pin":"{scl}","#,
+                r#"{{"board":"{board}","sensor_profile":"{sp}","#,
+                r#""sda_pin":"{sda}","scl_pin":"{scl}","#,
                 r#""power_pin":"{vcc}","ground_pin":"{gnd}","#,
                 r#""trig_pin":"{trig}","echo_pin":"{echo}","cam_pin":"{cam}","#,
                 r#""servo_pin":"{sv}","motor_pin":"{mot}","#,
                 r#""devices":[{devs}]}}"#
             ),
             board = board_str,
+            sp = self.sensor_profile.slug(),
             sda = json_escape(&self.sda_pin),
             scl = json_escape(&self.scl_pin),
             vcc = json_escape(&self.power_pin),
@@ -304,6 +440,7 @@ mod tests {
     fn wiring_config_to_json_contains_board_and_devices() {
         let json = WiringConfig::from_board(BoardProfile::OriginalEsp32).to_json();
         assert!(json.contains(r#""board":"esp32""#));
+        assert!(json.contains(r#""sensor_profile":"full""#));
         assert!(json.contains(r#""sda_pin":"GPIO21""#));
         assert!(json.contains(r#""address":"0x77""#));
         assert!(json.contains(r#""kind":"hc_sr04""#));
@@ -316,5 +453,108 @@ mod tests {
         assert!(json.contains(r#""kind":"vl53l0x""#));
         assert!(json.contains(r#""cam_pin":"GPIO0""#));
         assert!(json.contains(r#""motor_pin":"GPIO25""#));
+    }
+
+    // ── SensorProfile tests ────────────────────────────────────────────────
+
+    #[test]
+    fn sensor_profile_minimal_has_two_devices() {
+        let cfg = WiringConfig::from_board_with_sensors(
+            BoardProfile::OriginalEsp32,
+            SensorProfile::Minimal,
+        );
+        assert_eq!(cfg.devices.len(), 2);
+        assert_eq!(cfg.devices[0].kind, DeviceKind::Bme280);
+        assert_eq!(cfg.devices[1].kind, DeviceKind::Lcd1602);
+        assert_eq!(cfg.sensor_profile, SensorProfile::Minimal);
+    }
+
+    #[test]
+    fn sensor_profile_climate_station_has_five_devices() {
+        let cfg = WiringConfig::from_board_with_sensors(
+            BoardProfile::OriginalEsp32,
+            SensorProfile::ClimateStation,
+        );
+        assert_eq!(cfg.devices.len(), 5);
+        let kinds: Vec<_> = cfg.devices.iter().map(|d| &d.kind).collect();
+        assert!(kinds.contains(&&DeviceKind::Bme280));
+        assert!(kinds.contains(&&DeviceKind::Bh1750));
+        assert!(kinds.contains(&&DeviceKind::Sgp30));
+        assert!(kinds.contains(&&DeviceKind::Ds3231));
+        assert!(kinds.contains(&&DeviceKind::Lcd1602));
+    }
+
+    #[test]
+    fn sensor_profile_robot_base_has_five_devices() {
+        let cfg = WiringConfig::from_board_with_sensors(
+            BoardProfile::OriginalEsp32,
+            SensorProfile::RobotBase,
+        );
+        assert_eq!(cfg.devices.len(), 5);
+        let kinds: Vec<_> = cfg.devices.iter().map(|d| &d.kind).collect();
+        assert!(kinds.contains(&&DeviceKind::Mpu6050));
+        assert!(kinds.contains(&&DeviceKind::Vl53l0x));
+        assert!(kinds.contains(&&DeviceKind::HcSr04));
+        assert!(kinds.contains(&&DeviceKind::Servo));
+        assert!(kinds.contains(&&DeviceKind::L298n));
+    }
+
+    #[test]
+    fn sensor_profile_full_is_default_and_has_eleven_devices() {
+        let full =
+            WiringConfig::from_board_with_sensors(BoardProfile::OriginalEsp32, SensorProfile::Full);
+        let default = WiringConfig::from_board(BoardProfile::OriginalEsp32);
+        assert_eq!(full.devices.len(), 11);
+        assert_eq!(default.devices.len(), 11);
+        assert_eq!(full.sensor_profile, SensorProfile::Full);
+        assert_eq!(default.sensor_profile, SensorProfile::Full);
+    }
+
+    #[test]
+    fn sensor_profile_from_slug_roundtrips() {
+        for (slug, _) in SensorProfile::all() {
+            let parsed = SensorProfile::from_slug(slug);
+            assert!(parsed.is_some(), "slug '{slug}' should parse");
+            assert_eq!(parsed.unwrap().slug(), *slug);
+        }
+    }
+
+    #[test]
+    fn sensor_profile_from_slug_rejects_unknown() {
+        assert!(SensorProfile::from_slug("unknown-profile").is_none());
+        assert!(SensorProfile::from_slug("").is_none());
+    }
+
+    #[test]
+    fn sensor_profile_all_has_four_entries() {
+        assert_eq!(SensorProfile::all().len(), 4);
+    }
+
+    #[test]
+    fn wiring_config_json_includes_sensor_profile_slug() {
+        let cfg = WiringConfig::from_board_with_sensors(
+            BoardProfile::OriginalEsp32,
+            SensorProfile::ClimateStation,
+        );
+        let json = cfg.to_json();
+        assert!(json.contains(r#""sensor_profile":"climate""#));
+        assert!(!json.contains(r#""kind":"servo""#));
+        assert!(!json.contains(r#""kind":"hc_sr04""#));
+    }
+
+    #[test]
+    fn wiring_config_pins_are_board_specific_regardless_of_sensor_profile() {
+        let esp = WiringConfig::from_board_with_sensors(
+            BoardProfile::OriginalEsp32,
+            SensorProfile::Minimal,
+        );
+        let nano = WiringConfig::from_board_with_sensors(
+            BoardProfile::ArduinoNano,
+            SensorProfile::Minimal,
+        );
+        assert_eq!(esp.sda_pin, "GPIO21");
+        assert_eq!(nano.sda_pin, "A4");
+        // Both have the same sensor count despite different boards
+        assert_eq!(esp.devices.len(), nano.devices.len());
     }
 }

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -83,7 +83,12 @@ impl SensorProfile {
     /// assert_eq!(SensorProfile::all_variants()[0], SensorProfile::Full);
     /// ```
     pub fn all_variants() -> &'static [SensorProfile] {
-        &[Self::Full, Self::ClimateStation, Self::RobotBase, Self::Minimal]
+        &[
+            Self::Full,
+            Self::ClimateStation,
+            Self::RobotBase,
+            Self::Minimal,
+        ]
     }
 
     /// Returns all available sensor profiles as `(slug, display_name)` pairs.
@@ -136,6 +141,12 @@ impl SensorProfile {
                 DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
             ],
         }
+    }
+}
+
+impl Default for SensorProfile {
+    fn default() -> Self {
+        Self::Full
     }
 }
 
@@ -543,10 +554,19 @@ mod tests {
     fn sensor_profile_display_names_match_all_variants() {
         for p in SensorProfile::all_variants() {
             let name = p.display_name();
-            assert!(!name.is_empty(), "display_name() must not be empty for {:?}", p);
+            assert!(
+                !name.is_empty(),
+                "display_name() must not be empty for {:?}",
+                p
+            );
             // slug roundtrip
             assert_eq!(SensorProfile::from_slug(p.slug()).unwrap(), *p);
         }
+    }
+
+    #[test]
+    fn sensor_profile_default_is_full() {
+        assert_eq!(SensorProfile::default(), SensorProfile::Full);
     }
 
     #[test]

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -75,6 +75,17 @@ impl SensorProfile {
         }
     }
 
+    /// Returns all sensor profile variants.
+    ///
+    /// ```
+    /// use platform_pc_sim::wiring_config::SensorProfile;
+    /// assert_eq!(SensorProfile::all_variants().len(), 4);
+    /// assert_eq!(SensorProfile::all_variants()[0], SensorProfile::Full);
+    /// ```
+    pub fn all_variants() -> &'static [SensorProfile] {
+        &[Self::Full, Self::ClimateStation, Self::RobotBase, Self::Minimal]
+    }
+
     /// Returns all available sensor profiles as `(slug, display_name)` pairs.
     ///
     /// ```
@@ -83,13 +94,11 @@ impl SensorProfile {
     /// assert!(profiles.iter().any(|(slug, _)| *slug == "full"));
     /// assert!(profiles.iter().any(|(slug, _)| *slug == "climate"));
     /// ```
-    pub fn all() -> &'static [(&'static str, &'static str)] {
-        &[
-            ("full", "Full (all devices)"),
-            ("climate", "Climate Station"),
-            ("robot", "Robot Base"),
-            ("minimal", "Minimal (BME280 + LCD)"),
-        ]
+    pub fn all() -> Vec<(&'static str, &'static str)> {
+        Self::all_variants()
+            .iter()
+            .map(|p| (p.slug(), p.display_name()))
+            .collect()
     }
 
     /// Device kinds included in this profile.
@@ -515,7 +524,7 @@ mod tests {
         for (slug, _) in SensorProfile::all() {
             let parsed = SensorProfile::from_slug(slug);
             assert!(parsed.is_some(), "slug '{slug}' should parse");
-            assert_eq!(parsed.unwrap().slug(), *slug);
+            assert_eq!(parsed.unwrap().slug(), slug);
         }
     }
 
@@ -528,6 +537,16 @@ mod tests {
     #[test]
     fn sensor_profile_all_has_four_entries() {
         assert_eq!(SensorProfile::all().len(), 4);
+    }
+
+    #[test]
+    fn sensor_profile_display_names_match_all_variants() {
+        for p in SensorProfile::all_variants() {
+            let name = p.display_name();
+            assert!(!name.is_empty(), "display_name() must not be empty for {:?}", p);
+            // slug roundtrip
+            assert_eq!(SensorProfile::from_slug(p.slug()).unwrap(), *p);
+        }
     }
 
     #[test]

--- a/docs/sensors-and-actuators.md
+++ b/docs/sensors-and-actuators.md
@@ -368,6 +368,52 @@ curl http://127.0.0.1:7878/api/state | python3 -m json.tool
 
 ---
 
+## センサープロファイル (SensorProfile)
+
+`WiringConfig` はセンサーセットをプロファイルで切り替えられます。
+ダッシュボードの **Wiring Diagram** パネルにあるセレクタで切り替えるか、API 経由で指定します。
+
+### 利用可能なプロファイル
+
+| slug | 名前 | デバイス数 | 内容 |
+|------|------|-----------|------|
+| `full` | Full (all devices) | 11 | すべてのデバイス（デフォルト） |
+| `climate` | Climate Station | 5 | BME280, BH1750, SGP30, DS3231, LCD1602 |
+| `robot` | Robot Base | 5 | MPU6050, VL53L0X, HC-SR04, Servo, L298N |
+| `minimal` | Minimal | 2 | BME280, LCD1602 |
+
+### API 例
+
+```bash
+# 利用可能なプロファイル一覧
+curl http://127.0.0.1:7878/api/wiring/profiles
+
+# ボード + センサープロファイルを同時に切り替え
+curl -X POST http://127.0.0.1:7878/api/wiring \
+  -H "Content-Type: application/json" \
+  -d '{"board":"esp32", "sensor_profile":"climate"}'
+```
+
+### コード例
+
+```rust
+use platform_pc_sim::dashboard::BoardProfile;
+use platform_pc_sim::wiring_config::{SensorProfile, WiringConfig};
+
+// プロファイル指定
+let cfg = WiringConfig::from_board_with_sensors(
+    BoardProfile::OriginalEsp32,
+    SensorProfile::ClimateStation,
+);
+assert_eq!(cfg.devices.len(), 5);
+
+// スラッグからパース
+let profile = SensorProfile::from_slug("robot").unwrap();
+assert_eq!(profile, SensorProfile::RobotBase);
+```
+
+---
+
 ## 新しいセンサーを追加するには
 
 [porting-and-extension-guide.md](./porting-and-extension-guide.md) を参照してください。


### PR DESCRIPTION
## 概要

Closes #91

`WiringConfig` にセンサーセットを指定できる `SensorProfile` 列挙型を追加し、配線図とダッシュボードAPIをプロファイル切り替え対応にします。

## 変更内容

### 新機能: SensorProfile enum

| slug | 名前 | デバイス |
|------|------|---------|
| `full` | Full (all devices) | 全11デバイス（デフォルト） |
| `climate` | Climate Station | BME280 + BH1750 + SGP30 + DS3231 + LCD1602 |
| `robot` | Robot Base | MPU6050 + VL53L0X + HC-SR04 + Servo + L298N |
| `minimal` | Minimal | BME280 + LCD1602 |

### API

- `POST /api/wiring`: `sensor_profile` フィールドを受け付けるように拡張
  - `{"board":"esp32", "sensor_profile":"climate"}`
- `GET /api/wiring/profiles` (新規): 利用可能なプロファイル一覧を返す
  - レスポンス: `{"profiles":[{"slug":"full","name":"Full (all devices)"},...]`
- `GET /api/wiring/svg`: 現在のセンサープロファイルを反映したSVGを返す
- `to_json()`: `"sensor_profile":"<slug>"` フィールドを含むように更新

### ダッシュボードUI

Wiring Diagram パネルに Sensor Profile セレクタを追加。
ボードセレクタと連動して `POST /api/wiring` を呼び出します。

### 後方互換性

- `WiringConfig::from_board(board)` は変更なし（`Full` プロファイルを使用）
- `WiringConfig::from_board_with_sensors(board, sensor_profile)` を新規追加

### テスト (+13)

- `sensor_profile_minimal_has_two_devices`
- `sensor_profile_climate_station_has_five_devices`
- `sensor_profile_robot_base_has_five_devices`
- `sensor_profile_full_is_default_and_has_eleven_devices`
- `sensor_profile_from_slug_roundtrips`
- `sensor_profile_from_slug_rejects_unknown`
- `sensor_profile_all_has_four_entries`
- `wiring_config_json_includes_sensor_profile_slug`
- `wiring_config_pins_are_board_specific_regardless_of_sensor_profile`
- `parse_sensor_profile_from_json_*` (4本)

## テスト方法

```bash
cargo test --workspace --all-targets   # 294 tests
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```
