### PR TITLE
feat: add std feature flag to hal-api, core-app, reference-drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,13 @@ jobs:
           key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Check hal-api for no_std target
-        run: cargo check -p hal-api --lib --target $NO_STD_TARGET
+        run: cargo check -p hal-api --lib --target $NO_STD_TARGET --no-default-features
 
       - name: Check core-app for no_std target
-        run: cargo check -p core-app --lib --target $NO_STD_TARGET
+        run: cargo check -p core-app --lib --target $NO_STD_TARGET --no-default-features
 
       - name: Check reference-drivers for no_std target
-        run: cargo check -p reference-drivers --lib --target $NO_STD_TARGET
+        run: cargo check -p reference-drivers --lib --target $NO_STD_TARGET --no-default-features
 
       - name: Check platform-esp32 for no_std target
         run: cargo check -p platform-esp32 --lib --target $NO_STD_TARGET
@@ -192,13 +192,13 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Check hal-api for ESP32-C3
-        run: cargo check -p hal-api --lib --target $ESP32C3_TARGET
+        run: cargo check -p hal-api --lib --target $ESP32C3_TARGET --no-default-features
 
       - name: Check core-app for ESP32-C3
-        run: cargo check -p core-app --lib --target $ESP32C3_TARGET
+        run: cargo check -p core-app --lib --target $ESP32C3_TARGET --no-default-features
 
       - name: Check reference-drivers for ESP32-C3
-        run: cargo check -p reference-drivers --lib --target $ESP32C3_TARGET
+        run: cargo check -p reference-drivers --lib --target $ESP32C3_TARGET --no-default-features
 
       - name: Check platform-esp32 for ESP32-C3
         run: cargo check -p platform-esp32 --lib --target $ESP32C3_TARGET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.12] - 2026-05-07
+
+### Added
+- `[features] default = ["std"] / std = []` to `hal-api`, `core-app`, `reference-drivers`
+- `#![cfg_attr(not(feature = "std"), no_std)]` replaces hardcoded `#![no_std]` in all three crates
+- `std::fmt::Display` + `std::error::Error` impls for all 5 HAL error types (`GpioError`,
+  `I2cError`, `SensorError`, `DisplayError`, `ActuatorError`), gated with `#[cfg(feature = "std")]`
+- 9 new tests in `hal-api/error.rs` covering Display messages and Error trait bounds
+
+### Changed
+- `platform-esp32` and `platform-avr`: `hal-api`, `core-app`, `reference-drivers` deps now use
+  `default-features = false` so no_std propagates correctly through the dependency chain
+- CI `no-std` and `esp32c3` jobs: add `--no-default-features` to `hal-api`/`core-app`/
+  `reference-drivers` checks
+- Total tests: 306
+
+---
+
 ## [0.3.11] - 2025-07-16
 
 ### Added

--- a/crates/core-app/Cargo.toml
+++ b/crates/core-app/Cargo.toml
@@ -11,8 +11,12 @@ keywords = ["embedded", "application", "simulator", "no-std", "iot"]
 categories = ["embedded", "no-std"]
 rust-version = "1.66"
 
+[features]
+default = ["std"]
+std = ["hal-api/std"]
+
 [dependencies]
-hal-api = { version = "0.1.0", path = "../hal-api" }
+hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
 heapless = "0.8"
 
 [lib]

--- a/crates/core-app/lib.rs
+++ b/crates/core-app/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! # Core Application
 //!

--- a/crates/hal-api/Cargo.toml
+++ b/crates/hal-api/Cargo.toml
@@ -11,5 +11,9 @@ keywords = ["embedded", "hal", "mcu", "simulator", "no-std"]
 categories = ["embedded", "no-std", "hardware-support"]
 rust-version = "1.66"
 
+[features]
+default = ["std"]
+std = []
+
 [lib]
 path = "lib.rs"

--- a/crates/hal-api/error.rs
+++ b/crates/hal-api/error.rs
@@ -128,17 +128,6 @@ impl From<GpioError> for ActuatorError {
 }
 
 #[cfg(feature = "std")]
-mod std_impls {
-    use super::{ActuatorError, DisplayError, GpioError, I2cError, SensorError};
-
-    impl std::error::Error for GpioError {}
-    impl std::error::Error for I2cError {}
-    impl std::error::Error for SensorError {}
-    impl std::error::Error for DisplayError {}
-    impl std::error::Error for ActuatorError {}
-}
-
-#[cfg(feature = "std")]
 impl std::fmt::Display for GpioError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -147,6 +136,9 @@ impl std::fmt::Display for GpioError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for GpioError {}
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for I2cError {
@@ -158,6 +150,9 @@ impl std::fmt::Display for I2cError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for I2cError {}
 
 #[cfg(feature = "std")]
 impl std::fmt::Display for SensorError {
@@ -172,6 +167,9 @@ impl std::fmt::Display for SensorError {
 }
 
 #[cfg(feature = "std")]
+impl std::error::Error for SensorError {}
+
+#[cfg(feature = "std")]
 impl std::fmt::Display for DisplayError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -183,6 +181,9 @@ impl std::fmt::Display for DisplayError {
 }
 
 #[cfg(feature = "std")]
+impl std::error::Error for DisplayError {}
+
+#[cfg(feature = "std")]
 impl std::fmt::Display for ActuatorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -191,6 +192,9 @@ impl std::fmt::Display for ActuatorError {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for ActuatorError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/hal-api/error.rs
+++ b/crates/hal-api/error.rs
@@ -126,3 +126,161 @@ impl From<GpioError> for ActuatorError {
         ActuatorError::HardwareError
     }
 }
+
+#[cfg(feature = "std")]
+mod std_impls {
+    use super::{ActuatorError, DisplayError, GpioError, I2cError, SensorError};
+
+    impl std::error::Error for GpioError {}
+    impl std::error::Error for I2cError {}
+    impl std::error::Error for SensorError {}
+    impl std::error::Error for DisplayError {}
+    impl std::error::Error for ActuatorError {}
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for GpioError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GpioError::InvalidPin => write!(f, "invalid GPIO pin"),
+            GpioError::HardwareError => write!(f, "GPIO hardware error"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for I2cError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            I2cError::InvalidAddress => write!(f, "invalid I2C address"),
+            I2cError::BusError => write!(f, "I2C bus error"),
+            I2cError::Timeout => write!(f, "I2C timeout"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for SensorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SensorError::BusError => write!(f, "sensor bus error"),
+            SensorError::Busy => write!(f, "sensor busy"),
+            SensorError::InvalidReading => write!(f, "invalid sensor reading"),
+            SensorError::NotInitialized => write!(f, "sensor not initialized"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for DisplayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisplayError::BusError => write!(f, "display bus error"),
+            DisplayError::InvalidContent => write!(f, "invalid display content"),
+            DisplayError::NotInitialized => write!(f, "display not initialized"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for ActuatorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActuatorError::InvalidCommand => write!(f, "invalid actuator command"),
+            ActuatorError::HardwareError => write!(f, "actuator hardware error"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpio_error_debug() {
+        assert_eq!(format!("{:?}", GpioError::InvalidPin), "InvalidPin");
+        assert_eq!(format!("{:?}", GpioError::HardwareError), "HardwareError");
+    }
+
+    #[test]
+    fn i2c_error_debug() {
+        assert_eq!(format!("{:?}", I2cError::BusError), "BusError");
+        assert_eq!(format!("{:?}", I2cError::Timeout), "Timeout");
+        assert_eq!(format!("{:?}", I2cError::InvalidAddress), "InvalidAddress");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn gpio_error_display() {
+        assert_eq!(GpioError::InvalidPin.to_string(), "invalid GPIO pin");
+        assert_eq!(GpioError::HardwareError.to_string(), "GPIO hardware error");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn i2c_error_display() {
+        assert_eq!(I2cError::BusError.to_string(), "I2C bus error");
+        assert_eq!(I2cError::Timeout.to_string(), "I2C timeout");
+        assert_eq!(I2cError::InvalidAddress.to_string(), "invalid I2C address");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn sensor_error_display() {
+        assert_eq!(SensorError::BusError.to_string(), "sensor bus error");
+        assert_eq!(SensorError::Busy.to_string(), "sensor busy");
+        assert_eq!(
+            SensorError::InvalidReading.to_string(),
+            "invalid sensor reading"
+        );
+        assert_eq!(
+            SensorError::NotInitialized.to_string(),
+            "sensor not initialized"
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn display_error_display() {
+        assert_eq!(DisplayError::BusError.to_string(), "display bus error");
+        assert_eq!(
+            DisplayError::InvalidContent.to_string(),
+            "invalid display content"
+        );
+        assert_eq!(
+            DisplayError::NotInitialized.to_string(),
+            "display not initialized"
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn actuator_error_display() {
+        assert_eq!(
+            ActuatorError::InvalidCommand.to_string(),
+            "invalid actuator command"
+        );
+        assert_eq!(
+            ActuatorError::HardwareError.to_string(),
+            "actuator hardware error"
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn errors_implement_std_error() {
+        fn assert_error<E: std::error::Error>() {}
+        assert_error::<GpioError>();
+        assert_error::<I2cError>();
+        assert_error::<SensorError>();
+        assert_error::<DisplayError>();
+        assert_error::<ActuatorError>();
+    }
+
+    #[test]
+    fn actuator_from_gpio_error() {
+        let gpio_err = GpioError::HardwareError;
+        let act_err: ActuatorError = gpio_err.into();
+        assert_eq!(act_err, ActuatorError::HardwareError);
+    }
+}

--- a/crates/hal-api/lib.rs
+++ b/crates/hal-api/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! # HAL API
 //!

--- a/crates/platform-avr/Cargo.toml
+++ b/crates/platform-avr/Cargo.toml
@@ -14,10 +14,10 @@ publish = false
 
 [dependencies]
 embedded-hal = "1.0"
-hal-api = { version = "0.1.0", path = "../hal-api" }
+hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
 
 [lib]
 path = "lib.rs"
 
 [dev-dependencies]
-core-app = { version = "0.1.0", path = "../core-app" }
+core-app = { version = "0.1.0", path = "../core-app", default-features = false }

--- a/crates/platform-esp32/Cargo.toml
+++ b/crates/platform-esp32/Cargo.toml
@@ -14,11 +14,11 @@ publish = false
 
 [dependencies]
 embedded-hal = "1.0"
-hal-api = { version = "0.1.0", path = "../hal-api" }
-reference-drivers = { version = "0.1.0", path = "../reference-drivers" }
+hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
+reference-drivers = { version = "0.1.0", path = "../reference-drivers", default-features = false }
 
 [lib]
 path = "lib.rs"
 
 [dev-dependencies]
-core-app = { version = "0.1.0", path = "../core-app" }
+core-app = { version = "0.1.0", path = "../core-app", default-features = false }

--- a/crates/reference-drivers/Cargo.toml
+++ b/crates/reference-drivers/Cargo.toml
@@ -11,9 +11,13 @@ keywords = ["embedded", "bme280", "lcd1602", "i2c", "no-std"]
 categories = ["embedded", "no-std", "hardware-support"]
 rust-version = "1.66"
 
+[features]
+default = ["std"]
+std = ["hal-api/std"]
+
 [dependencies]
 embedded-hal = "1.0"
-hal-api = { version = "0.1.0", path = "../hal-api" }
+hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/crates/reference-drivers/lib.rs
+++ b/crates/reference-drivers/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! # Reference Drivers
 //!


### PR DESCRIPTION
## 概要

`hal-api` / `core-app` / `reference-drivers` に `std` feature flag を追加し、no_std 依存チェーンを正しく管理できるようにする。

## 変更内容

### feature flag 追加
- `core-app`: 同様 + `std = ["hal-api/std"]` で依存チェーン伝播
- `reference-drivers`: 同様

### std::error::Error / Display impl 追加 (hal-api/error.rs)
- `GpioError`, `I2cError`, `SensorError`, `DisplayError`, `ActuatorError` の 5 型に対して `#[cfg(feature = "std")]` で条件付き実装
- 10 個の Display / Error テスト追加

### default-features = false に変更
- `platform-esp32` と `platform-avr` の dep 宣言を修正し、no_std 伝播が正しく動くように

### CI 更新
- `no-std` job と `esp32c3` job で `hal-api` / `core-app` / `reference-drivers` に `--no-default-features` を追加

## テスト

```bash
cargo test --workspace --all-targets  # 306 tests
cargo check -p hal-api --lib --target thumbv6m-none-eabi --no-default-features  # OK
cargo check -p core-app --lib --target thumbv6m-none-eabi --no-default-features  # OK
cargo check -p reference-drivers --lib --target thumbv6m-none-eabi --no-default-features  # OK
cargo check -p platform-esp32 --lib --target thumbv6m-none-eabi  # OK
cargo check -p platform-avr --lib --target thumbv6m-none-eabi  # OK
```

Closes #93