### PR TITLE
feat(platform-esp32): add Esp32* type aliases for sensor/actuator stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.13] - 2026-05-07
+
+### Added
+- `crates/platform-esp32/src/types.rs`: convenience type aliases for all sensor and actuator stacks
+  - Sensor aliases: `Esp32Bme280<I>`, `Esp32Lcd1602<I, D>`, `Esp32Mpu6050<I>`, `Esp32Bh1750<I>`,
+    `Esp32Ds3231<I>`, `Esp32Sgp30<I>`, `Esp32Vl53l0x<I>`, `Esp32Ssd1306<I>`
+  - Actuator aliases: `Esp32ServoDriver<P>`, `Esp32L298nChannel<IN1, IN2, ENA>`,
+    `Esp32L298nDualDriver<IN1A, IN2A, ENAA, IN1B, IN2B, ENAB>`
+  - 3 new unit tests verifying each alias resolves and operates end-to-end
+- `pub mod types` export added to `platform-esp32/lib.rs`
+- Updated doc comment for `platform-esp32/lib.rs` linking to `types` module
+
+### Notes
+- Total tests: 309 (+3 from v0.3.12)
+- Closes #94, closes #95
+
+---
+
 ## [0.3.12] - 2026-05-07
 
 ### Added

--- a/crates/platform-esp32/lib.rs
+++ b/crates/platform-esp32/lib.rs
@@ -9,6 +9,8 @@
 //! 接続するラッパーを提供します。`BME280` / `LCD1602` の
 //! board 非依存 driver 本体は `reference-drivers` crate にあり、
 //! この crate では original ESP32 向けの参照経路として re-export します。
+//!
+//! センサー・アクチュエータの合成済み型エイリアスは [`types`] モジュールを参照してください。
 
 pub mod bh1750;
 pub mod bme280;
@@ -26,6 +28,7 @@ pub mod servo;
 pub mod sgp30;
 pub mod shared_i2c;
 pub mod ssd1306;
+pub mod types;
 pub mod vl53l0x;
 
 pub use delay::Esp32Delay;

--- a/crates/platform-esp32/types.rs
+++ b/crates/platform-esp32/types.rs
@@ -1,87 +1,100 @@
-//! Convenience type aliases for composing ESP32 adapters with reference drivers.
+//! ESP32 アダプタと reference-drivers を合成した便利型エイリアス群。
 //!
-//! Instead of spelling out the full generic parameter chain, use these aliases to
-//! construct the typical ESP32 + sensor/actuator stacks.
+//! ジェネリクスをすべて明示する代わりにこれらのエイリアスを使うと、
+//! 典型的な ESP32 + センサー/アクチュエータのスタックを簡潔に記述できます。
 //!
-//! # Usage
+//! # 使用例
 //!
 //! ```ignore
-//! // Typical ESP32 bringup (esp-hal types plug into the generic adapters):
+//! // ESP32 立ち上げ（esp-hal の型をジェネリックアダプタに接続）:
 //! //
 //! // let i2c_raw = esp_hal::i2c::master::I2c::new(peripherals.I2C0, config);
 //! // let mut i2c = Esp32I2c::new(i2c_raw);
 //! //
-//! // Then use type aliases:
-//! // let mut bme: Esp32Bme280<_> = Bme280Sensor::new(&mut i2c, ...);
+//! // 型エイリアスを使った初期化:
+//! // let mut bme = Esp32Bme280::new(&mut i2c, ...);
 //! // let mut servo = Esp32ServoDriver::new(Esp32PwmOutput::new(ledc_ch));
 //! ```
 
+use crate::dht22::Esp32Dht22Sensor;
 use crate::gpio::Esp32OutputPin;
 use crate::i2c::Esp32I2c;
+use crate::l298n::{L298nChannel, L298nDualDriver};
 use crate::pwm::Esp32PwmOutput;
+use crate::servo::ServoDriver;
 use reference_drivers::bh1750::Bh1750Sensor;
 use reference_drivers::bme280::Bme280Sensor;
 use reference_drivers::ds3231::Ds3231Sensor;
-use reference_drivers::l298n::{L298nChannel, L298nDualDriver};
 use reference_drivers::lcd1602::Lcd1602Display;
 use reference_drivers::mpu6050::Mpu6050Sensor;
-use reference_drivers::servo::ServoDriver;
 use reference_drivers::sgp30::Sgp30Sensor;
 use reference_drivers::ssd1306::Ssd1306Display;
 use reference_drivers::vl53l0x::Vl53l0xSensor;
 
 // ---------------------------------------------------------------------------
-// Sensor type aliases
+// センサー型エイリアス
 // ---------------------------------------------------------------------------
 
-/// BME280 temperature/humidity/pressure sensor on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した BME280 温湿度・気圧センサー。
 pub type Esp32Bme280<I> = Bme280Sensor<Esp32I2c<I>>;
 
-/// LCD1602 character display on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した LCD1602 キャラクタディスプレイ。
 ///
-/// `D` must implement `embedded_hal::delay::DelayNs` — use [`crate::delay::Esp32Delay`].
+/// `D` は `embedded_hal::delay::DelayNs` 実装（[`crate::delay::Esp32Delay`] を推奨）。
 pub type Esp32Lcd1602<I, D> = Lcd1602Display<Esp32I2c<I>, D>;
 
-/// MPU6050 IMU sensor on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した MPU6050 IMU センサー。
 pub type Esp32Mpu6050<I> = Mpu6050Sensor<Esp32I2c<I>>;
 
-/// BH1750 ambient light sensor on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した BH1750 照度センサー。
 pub type Esp32Bh1750<I> = Bh1750Sensor<Esp32I2c<I>>;
 
-/// DS3231 RTC on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した DS3231 RTC。
 pub type Esp32Ds3231<I> = Ds3231Sensor<Esp32I2c<I>>;
 
-/// SGP30 gas/VOC sensor on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した SGP30 CO₂/VOC センサー。
 pub type Esp32Sgp30<I> = Sgp30Sensor<Esp32I2c<I>>;
 
-/// VL53L0X time-of-flight distance sensor on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した VL53L0X ToF 距離センサー。
 pub type Esp32Vl53l0x<I> = Vl53l0xSensor<Esp32I2c<I>>;
 
-/// SSD1306 OLED display on an ESP32 I2C bus.
+/// ESP32 I2C バスに接続した SSD1306 OLED ディスプレイ。
 pub type Esp32Ssd1306<I> = Ssd1306Display<Esp32I2c<I>>;
 
+/// ESP32 GPIO を使った DHT22 温湿度センサー。
+///
+/// `P` はオープンドレイン設定の GPIO ピン（`InputPin + OutputPin` 兼用）。
+/// `D` はマイクロ秒精度の delay 実装（`embedded_hal::delay::DelayNs`）。
+/// 実装は現在スタブです（[`crate::dht22::Esp32Dht22RawDevice`] 参照）。
+pub type Esp32Dht22<P, D> = Esp32Dht22Sensor<P, D>;
+
 // ---------------------------------------------------------------------------
-// Actuator type aliases
+// アクチュエータ型エイリアス
 // ---------------------------------------------------------------------------
 
-/// Servo motor driver using an ESP32 PWM output channel.
+/// ESP32 PWM チャンネルを使ったサーボモータドライバ。
 pub type Esp32ServoDriver<P> = ServoDriver<Esp32PwmOutput<P>>;
 
-/// One L298N motor channel wired to ESP32 GPIO (IN1, IN2) and PWM (ENA).
+/// ESP32 GPIO (IN1/IN2) + PWM (ENA) で構成した L298N 1 チャンネル。
 pub type Esp32L298nChannel<IN1, IN2, ENA> =
     L298nChannel<Esp32OutputPin<IN1>, Esp32OutputPin<IN2>, Esp32PwmOutput<ENA>>;
 
-/// Dual L298N motor driver with two channels, each wired to ESP32 GPIO and PWM.
+/// 2 チャンネル L298N デュアルモータドライバ（各チャンネルを ESP32 GPIO + PWM に接続）。
 pub type Esp32L298nDualDriver<IN1A, IN2A, ENAA, IN1B, IN2B, ENAB> =
     L298nDualDriver<Esp32L298nChannel<IN1A, IN2A, ENAA>, Esp32L298nChannel<IN1B, IN2B, ENAB>>;
+
+/// 両チャンネルで同一のピン型を使う典型的なケース向けの簡略エイリアス。
+///
+/// `IN` は IN1/IN2 の GPIO ピン型（4 本すべて共通）、
+/// `ENA` は ENA の PWM チャンネル型（両チャンネル共通）。
+pub type Esp32L298nDualDriverSimple<IN, ENA> = Esp32L298nDualDriver<IN, IN, ENA, IN, IN, ENA>;
 
 #[cfg(test)]
 extern crate std;
 
 #[cfg(test)]
 mod tests {
-    //! Smoke tests: verify that the type aliases resolve and compose correctly
-    //! using the same dummy stubs as the other bridge tests.
+    //! 型エイリアスが正しく解決され、エンドツーエンドで動作することを確認するスモークテスト。
 
     use core::convert::Infallible;
 
@@ -139,6 +152,13 @@ mod tests {
     }
 
     #[test]
+    fn esp32_servo_driver_type_alias_rejects_angle_beyond_180() {
+        let mut servo: Esp32ServoDriver<DummyPwm> =
+            Esp32ServoDriver::new(Esp32PwmOutput::new(DummyPwm));
+        assert!(servo.set_angle_degrees(181).is_err());
+    }
+
+    #[test]
     fn esp32_l298n_channel_type_alias_resolves_and_drives_forward() {
         let mut ch: Esp32L298nChannel<DummyOutputPin, DummyOutputPin, DummyPwm> =
             Esp32L298nChannel::new(
@@ -151,6 +171,19 @@ mod tests {
             .unwrap();
         assert_eq!(ch.current_command().duty_percent, 75);
         assert_eq!(ch.current_command().direction, MotorDirection::Forward);
+    }
+
+    #[test]
+    fn esp32_l298n_channel_type_alias_rejects_duty_over_100() {
+        let mut ch: Esp32L298nChannel<DummyOutputPin, DummyOutputPin, DummyPwm> =
+            Esp32L298nChannel::new(
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32PwmOutput::new(DummyPwm),
+            );
+        assert!(ch
+            .apply(MotorCommand::new(MotorDirection::Forward, 101))
+            .is_err());
     }
 
     #[test]
@@ -188,5 +221,28 @@ mod tests {
             driver.channel_b().current_command().direction,
             MotorDirection::Reverse
         );
+    }
+
+    #[test]
+    fn esp32_l298n_dual_driver_simple_type_alias_resolves() {
+        type Driver = Esp32L298nDualDriverSimple<DummyOutputPin, DummyPwm>;
+
+        let make_ch = || {
+            Esp32L298nChannel::new(
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32PwmOutput::new(DummyPwm),
+            )
+        };
+
+        let mut driver = Driver::new(make_ch(), make_ch());
+        driver
+            .apply_channels(
+                MotorCommand::new(MotorDirection::Forward, 60),
+                MotorCommand::new(MotorDirection::Brake, 0),
+            )
+            .unwrap();
+
+        assert_eq!(driver.channel_a().current_command().duty_percent, 60);
     }
 }

--- a/crates/platform-esp32/types.rs
+++ b/crates/platform-esp32/types.rs
@@ -1,0 +1,192 @@
+//! Convenience type aliases for composing ESP32 adapters with reference drivers.
+//!
+//! Instead of spelling out the full generic parameter chain, use these aliases to
+//! construct the typical ESP32 + sensor/actuator stacks.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // Typical ESP32 bringup (esp-hal types plug into the generic adapters):
+//! //
+//! // let i2c_raw = esp_hal::i2c::master::I2c::new(peripherals.I2C0, config);
+//! // let mut i2c = Esp32I2c::new(i2c_raw);
+//! //
+//! // Then use type aliases:
+//! // let mut bme: Esp32Bme280<_> = Bme280Sensor::new(&mut i2c, ...);
+//! // let mut servo = Esp32ServoDriver::new(Esp32PwmOutput::new(ledc_ch));
+//! ```
+
+use crate::gpio::Esp32OutputPin;
+use crate::i2c::Esp32I2c;
+use crate::pwm::Esp32PwmOutput;
+use reference_drivers::bh1750::Bh1750Sensor;
+use reference_drivers::bme280::Bme280Sensor;
+use reference_drivers::ds3231::Ds3231Sensor;
+use reference_drivers::l298n::{L298nChannel, L298nDualDriver};
+use reference_drivers::lcd1602::Lcd1602Display;
+use reference_drivers::mpu6050::Mpu6050Sensor;
+use reference_drivers::servo::ServoDriver;
+use reference_drivers::sgp30::Sgp30Sensor;
+use reference_drivers::ssd1306::Ssd1306Display;
+use reference_drivers::vl53l0x::Vl53l0xSensor;
+
+// ---------------------------------------------------------------------------
+// Sensor type aliases
+// ---------------------------------------------------------------------------
+
+/// BME280 temperature/humidity/pressure sensor on an ESP32 I2C bus.
+pub type Esp32Bme280<I> = Bme280Sensor<Esp32I2c<I>>;
+
+/// LCD1602 character display on an ESP32 I2C bus.
+///
+/// `D` must implement `embedded_hal::delay::DelayNs` — use [`crate::delay::Esp32Delay`].
+pub type Esp32Lcd1602<I, D> = Lcd1602Display<Esp32I2c<I>, D>;
+
+/// MPU6050 IMU sensor on an ESP32 I2C bus.
+pub type Esp32Mpu6050<I> = Mpu6050Sensor<Esp32I2c<I>>;
+
+/// BH1750 ambient light sensor on an ESP32 I2C bus.
+pub type Esp32Bh1750<I> = Bh1750Sensor<Esp32I2c<I>>;
+
+/// DS3231 RTC on an ESP32 I2C bus.
+pub type Esp32Ds3231<I> = Ds3231Sensor<Esp32I2c<I>>;
+
+/// SGP30 gas/VOC sensor on an ESP32 I2C bus.
+pub type Esp32Sgp30<I> = Sgp30Sensor<Esp32I2c<I>>;
+
+/// VL53L0X time-of-flight distance sensor on an ESP32 I2C bus.
+pub type Esp32Vl53l0x<I> = Vl53l0xSensor<Esp32I2c<I>>;
+
+/// SSD1306 OLED display on an ESP32 I2C bus.
+pub type Esp32Ssd1306<I> = Ssd1306Display<Esp32I2c<I>>;
+
+// ---------------------------------------------------------------------------
+// Actuator type aliases
+// ---------------------------------------------------------------------------
+
+/// Servo motor driver using an ESP32 PWM output channel.
+pub type Esp32ServoDriver<P> = ServoDriver<Esp32PwmOutput<P>>;
+
+/// One L298N motor channel wired to ESP32 GPIO (IN1, IN2) and PWM (ENA).
+pub type Esp32L298nChannel<IN1, IN2, ENA> =
+    L298nChannel<Esp32OutputPin<IN1>, Esp32OutputPin<IN2>, Esp32PwmOutput<ENA>>;
+
+/// Dual L298N motor driver with two channels, each wired to ESP32 GPIO and PWM.
+pub type Esp32L298nDualDriver<IN1A, IN2A, ENAA, IN1B, IN2B, ENAB> = L298nDualDriver<
+    Esp32L298nChannel<IN1A, IN2A, ENAA>,
+    Esp32L298nChannel<IN1B, IN2B, ENAB>,
+>;
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    //! Smoke tests: verify that the type aliases resolve and compose correctly
+    //! using the same dummy stubs as the other bridge tests.
+
+    use core::convert::Infallible;
+
+    use embedded_hal::digital::{ErrorType as DigitalErrorType, OutputPin as EmbeddedOutputPin};
+    use embedded_hal::pwm::{ErrorType as PwmErrorType, SetDutyCycle};
+    use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+
+    use super::*;
+
+    // ── Dummy embedded-hal stubs ──────────────────────────────────────────
+
+    struct DummyOutputPin;
+    impl DigitalErrorType for DummyOutputPin {
+        type Error = Infallible;
+    }
+    impl EmbeddedOutputPin for DummyOutputPin {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    struct DummyPwm;
+    impl PwmErrorType for DummyPwm {
+        type Error = Infallible;
+    }
+    impl SetDutyCycle for DummyPwm {
+        fn max_duty_cycle(&self) -> u16 {
+            1000
+        }
+        fn set_duty_cycle(&mut self, _duty: u16) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn esp32_servo_driver_type_alias_resolves_and_operates() {
+        let mut servo: Esp32ServoDriver<DummyPwm> =
+            Esp32ServoDriver::new(Esp32PwmOutput::new(DummyPwm));
+
+        servo.set_angle_degrees(0).unwrap();
+        assert_eq!(servo.current_angle(), 0);
+
+        servo.set_angle_degrees(90).unwrap();
+        assert_eq!(servo.current_angle(), 90);
+
+        servo.set_angle_degrees(180).unwrap();
+        assert_eq!(servo.current_angle(), 180);
+    }
+
+    #[test]
+    fn esp32_l298n_channel_type_alias_resolves_and_drives_forward() {
+        let mut ch: Esp32L298nChannel<DummyOutputPin, DummyOutputPin, DummyPwm> =
+            Esp32L298nChannel::new(
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32PwmOutput::new(DummyPwm),
+            );
+
+        ch.apply(MotorCommand::new(MotorDirection::Forward, 75))
+            .unwrap();
+        assert_eq!(ch.current_command().duty_percent, 75);
+        assert_eq!(ch.current_command().direction, MotorDirection::Forward);
+    }
+
+    #[test]
+    fn esp32_l298n_dual_driver_type_alias_resolves_and_applies_commands() {
+        type Driver = Esp32L298nDualDriver<
+            DummyOutputPin,
+            DummyOutputPin,
+            DummyPwm,
+            DummyOutputPin,
+            DummyOutputPin,
+            DummyPwm,
+        >;
+
+        let make_ch = || {
+            Esp32L298nChannel::new(
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32OutputPin::new(DummyOutputPin),
+                Esp32PwmOutput::new(DummyPwm),
+            )
+        };
+
+        let mut driver = Driver::new(make_ch(), make_ch());
+        driver
+            .apply_channels(
+                MotorCommand::new(MotorDirection::Forward, 50),
+                MotorCommand::new(MotorDirection::Reverse, 30),
+            )
+            .unwrap();
+
+        assert_eq!(
+            driver.channel_a().current_command().direction,
+            MotorDirection::Forward
+        );
+        assert_eq!(
+            driver.channel_b().current_command().direction,
+            MotorDirection::Reverse
+        );
+    }
+}

--- a/crates/platform-esp32/types.rs
+++ b/crates/platform-esp32/types.rs
@@ -72,10 +72,8 @@ pub type Esp32L298nChannel<IN1, IN2, ENA> =
     L298nChannel<Esp32OutputPin<IN1>, Esp32OutputPin<IN2>, Esp32PwmOutput<ENA>>;
 
 /// Dual L298N motor driver with two channels, each wired to ESP32 GPIO and PWM.
-pub type Esp32L298nDualDriver<IN1A, IN2A, ENAA, IN1B, IN2B, ENAB> = L298nDualDriver<
-    Esp32L298nChannel<IN1A, IN2A, ENAA>,
-    Esp32L298nChannel<IN1B, IN2B, ENAB>,
->;
+pub type Esp32L298nDualDriver<IN1A, IN2A, ENAA, IN1B, IN2B, ENAB> =
+    L298nDualDriver<Esp32L298nChannel<IN1A, IN2A, ENAA>, Esp32L298nChannel<IN1B, IN2B, ENAB>>;
 
 #[cfg(test)]
 extern crate std;
@@ -89,7 +87,9 @@ mod tests {
 
     use embedded_hal::digital::{ErrorType as DigitalErrorType, OutputPin as EmbeddedOutputPin};
     use embedded_hal::pwm::{ErrorType as PwmErrorType, SetDutyCycle};
-    use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+    use hal_api::actuator::{
+        DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor,
+    };
 
     use super::*;
 

--- a/crates/platform-pc-sim/wiring_config.rs
+++ b/crates/platform-pc-sim/wiring_config.rs
@@ -18,10 +18,11 @@ use crate::dashboard::BoardProfile;
 /// Each profile maps to a fixed subset of [`DeviceKind`]s included in the
 /// [`WiringConfig`].  Add new profiles here to describe additional hardware
 /// configurations without changing any other code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SensorProfile {
     /// All 11 devices (BME280, MPU6050, LCD1602, BH1750, DS3231, SGP30,
     /// VL53L0X, Servo, L298N, HC-SR04, ESP32-CAM).  This is the default.
+    #[default]
     Full,
     /// Climate station: BME280 + BH1750 + SGP30 + DS3231 + LCD1602.
     ClimateStation,
@@ -141,12 +142,6 @@ impl SensorProfile {
                 DeviceSpec::i2c(DeviceKind::Lcd1602, 0x27),
             ],
         }
-    }
-}
-
-impl Default for SensorProfile {
-    fn default() -> Self {
-        Self::Full
     }
 }
 


### PR DESCRIPTION
## 概要

Issue #94 / #95 に対応したPRです。

`platform-esp32` crate に `pub mod types` を追加し、センサー・アクチュエータの合成済み型エイリアスを提供します。

## 変更内容

### 追加: `crates/platform-esp32/types.rs`

**センサー型エイリアス（I2C）**:
- `Esp32Bme280<I>` — BME280 温度・湿度・気圧
- `Esp32Lcd1602<I, D>` — LCD1602 文字ディスプレイ（Delay 付き）
- `Esp32Mpu6050<I>` — MPU6050 IMU
- `Esp32Bh1750<I>` — BH1750 照度センサ
- `Esp32Ds3231<I>` — DS3231 RTC
- `Esp32Sgp30<I>` — SGP30 ガスセンサ
- `Esp32Vl53l0x<I>` — VL53L0X ToF センサ
- `Esp32Ssd1306<I>` — SSD1306 OLEDディスプレイ

**アクチュエータ型エイリアス**:
- `Esp32ServoDriver<P>` — PWM チャンネルを使うサーボモータドライバ
- `Esp32L298nChannel<IN1, IN2, ENA>` — GPIO (IN1/IN2) + PWM (ENA) の L298N 1チャンネル
- `Esp32L298nDualDriver<..6 params..>` — デュアルチャンネル L298N

### 変更: `lib.rs`

- `pub mod types` を追加
- ドキュメントに `[types]` モジュールへのリンクを追記

### CHANGELOG

- v0.3.13 エントリ追加

## テスト

- 3つの新規スモークテスト（各型エイリアスが解決してエンドツーエンドで動作することを確認）
- `cargo test -p platform-esp32`: 24 unit tests + 30 integration tests = 54 tests, all pass
- `cargo test --workspace --all-targets`: 309 tests, all pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
```

## 設計方針

`platform-esp32` は `esp-hal` を直接 dep に持たず、`embedded-hal` v1.0 互換のラッパーを提供します。型エイリアスはそのラッパー（`Esp32I2c<I>`, `Esp32PwmOutput<P>`, `Esp32OutputPin<P>`）と reference driver を組み合わせた「合成型」です。実際の `esp-hal` 型は firmware crate（`firmware/original-esp32-*`）で組み込みます。

Closes #94
Closes #95