### PR TITLE
feat(firmware): add original-esp32-robot-base skeleton (Servo + L298N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.14] - 2026-05-07
+
+### Added
+- `firmware/original-esp32-robot-base/`: ESP32 robot base firmware skeleton
+  - Servo motor control via LEDC PWM (GPIO 18, 50 Hz, SG90 compatible)
+  - Dual motor driver (L298N) via GPIO + LEDC PWM (6 pins: IN1/IN2/EN per channel)
+  - Demo sequence: Forward → Turn → Brake → Reverse cycling every 1 s
+  - Uses `Esp32ServoDriver<LedcChannel>` and `Esp32L298nDualDriverSimple<Output, LedcChannel>`
+    type aliases from `platform_esp32::types`
+  - `README.md` with wiring table, power diagram, build/flash instructions
+- Closes #98
+
+### Notes
+- Total tests: 312 (unchanged — firmware crate is standalone `[workspace]`)
+
+---
+
 ## [0.3.13] - 2026-05-07
 
 ### Added

--- a/firmware/original-esp32-robot-base/.cargo/config.toml
+++ b/firmware/original-esp32-robot-base/.cargo/config.toml
@@ -1,0 +1,15 @@
+[build]
+target = "xtensa-esp32-none-elf"
+
+[target.'cfg(target_arch = "xtensa")']
+runner = "espflash flash --monitor"
+rustflags = [
+  "-C", "link-arg=-Wl,-Tlinkall.x",
+  "-C", "link-arg=-nostartfiles",
+]
+
+[env]
+ESP_LOG = "info"
+
+[unstable]
+build-std = ["core", "alloc"]

--- a/firmware/original-esp32-robot-base/Cargo.toml
+++ b/firmware/original-esp32-robot-base/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "original-esp32-robot-base"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+hal-api = { path = "../../crates/hal-api", default-features = false }
+platform-esp32 = { path = "../../crates/platform-esp32", default-features = false }
+embedded-hal = "1.0"
+esp-backtrace = { version = "0.18.0", features = ["panic-handler", "println", "esp32"] }
+esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp32"] }
+esp-hal = { version = "1.0.0", features = ["esp32"] }
+esp-println = { version = "0.16.0", features = ["esp32"] }
+
+[profile.release]
+debug = true
+debug-assertions = true
+lto = "fat"
+codegen-units = 1
+
+[patch.crates-io]
+esp-rom-sys = { path = "../../vendor/esp-rom-sys" }

--- a/firmware/original-esp32-robot-base/README.md
+++ b/firmware/original-esp32-robot-base/README.md
@@ -1,0 +1,102 @@
+# original-esp32-robot-base
+
+ESP32 ロボットベース ファームウェアスケルトン。
+
+`platform-esp32` の [`Esp32ServoDriver`] / [`Esp32L298nDualDriverSimple`] 型エイリアスを使った
+サーボモータ + デュアルモータドライバの実機接続例です。
+
+## 機能
+
+- サーボモータ（SG90 等）を LEDC PWM で 0°〜180° 制御
+- L298N デュアルモータドライバを GPIO + LEDC PWM で制御
+- デモシーケンス（前進 → 旋回 → 停止 → 後退）をループ再生
+
+## アーキテクチャ
+
+```
+esp_hal::ledc::Channel ──→ Esp32PwmOutput ──→ Esp32ServoDriver
+esp_hal::gpio::Output  ──→ Esp32OutputPin  ──┐
+                                              ├─→ Esp32L298nChannel ──→ Esp32L298nDualDriverSimple
+esp_hal::ledc::Channel ──→ Esp32PwmOutput  ──┘
+```
+
+`Esp32ServoDriver` と `Esp32L298nDualDriverSimple` は
+`crates/platform-esp32/types.rs` で定義された型エイリアスです。
+
+## 配線
+
+### サーボモータ（SG90 等）
+
+| 信号 | ESP32 GPIO | 備考 |
+|------|-----------|------|
+| PWM  | GPIO 18   | LEDC Ch0, 50 Hz, 14-bit |
+
+### L298N デュアルモータドライバ
+
+| 信号  | ESP32 GPIO | 備考 |
+|------|-----------|------|
+| IN1-A | GPIO 25 | チャンネル A 方向 1 |
+| IN2-A | GPIO 26 | チャンネル A 方向 2 |
+| ENA   | GPIO 27 | チャンネル A PWM (LEDC Ch1, 1 kHz) |
+| IN1-B | GPIO 32 | チャンネル B 方向 1 |
+| IN2-B | GPIO 33 | チャンネル B 方向 2 |
+| ENB   | GPIO 14 | チャンネル B PWM (LEDC Ch2, 1 kHz) |
+
+> **注**: L298N の 5 V 論理ラインは ESP32 の 3.3 V GPIO と直結できます（L298N の入力は 3 V〜5 V 対応）。
+
+### 電源
+
+| ライン | 電圧 |
+|--------|------|
+| ESP32  | 5 V（USB または VIN） |
+| サーボ | 5 V（ESP32 とは別電源推奨） |
+| L298N  | 6〜12 V（モータ電源） |
+| L298N 5 V | ESP32 の 5 V ピンへ供給可 |
+
+## 必要なツール
+
+```bash
+# xtensa ツールチェーンのインストール（初回のみ）
+cargo install espup
+espup install
+source $HOME/export-esp.sh
+
+# espflash のインストール
+cargo install espflash
+```
+
+## ビルドと書き込み
+
+```bash
+cd firmware/original-esp32-robot-base
+
+# ビルドのみ
+cargo build --release
+
+# フラッシュ書き込み + シリアルモニタ（macOS: /dev/tty.usbserial-*）
+cargo run --release
+
+# デバイスを明示指定する場合
+espflash flash --port /dev/tty.usbserial-0001 target/xtensa-esp32-none-elf/release/original-esp32-robot-base --monitor
+```
+
+## 期待される出力
+
+```
+=== ESP32 Robot Base Firmware ===
+Servo: GPIO 18
+Motor A: IN1=25 IN2=26 ENA=27
+Motor B: IN1=32 IN2=33 ENB=14
+[tick 0] step 0 — servo=0° Forward@50%
+[tick 50] step 1 — servo=45° Forward@75%
+[tick 100] step 2 — servo=90° Brake@50%
+[tick 150] step 3 — servo=135° Reverse@60%
+[tick 200] step 4 — servo=180° Reverse@40%
+[tick 250] step 5 — servo=90° Brake@0%
+```
+
+## 関連
+
+- [`crates/platform-esp32/types.rs`](../../crates/platform-esp32/types.rs) — 型エイリアス定義
+- [`firmware/original-esp32-climate-display`](../original-esp32-climate-display/) — センサー版（I2C）
+- [`crates/platform-esp32/tests/servo_motor_bridge.rs`](../../crates/platform-esp32/tests/servo_motor_bridge.rs) — ブリッジテスト

--- a/firmware/original-esp32-robot-base/rust-toolchain.toml
+++ b/firmware/original-esp32-robot-base/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "esp"
+components = ["rust-src"]

--- a/firmware/original-esp32-robot-base/src/main.rs
+++ b/firmware/original-esp32-robot-base/src/main.rs
@@ -1,0 +1,230 @@
+//! # original-esp32-robot-base
+//!
+//! ESP32 ロボットベース ファームウェアスケルトン。
+//! `Esp32ServoDriver` と `Esp32L298nDualDriverSimple` を使ったサーボ + デュアルモータ制御の
+//! 実機接続例です。
+//!
+//! ## 配線
+//!
+//! ### サーボモータ（SG90 等）
+//!
+//! | 信号 | ESP32 GPIO | 備考 |
+//! |------|-----------|------|
+//! | PWM  | GPIO 18   | LEDC チャンネル 0, 50 Hz |
+//!
+//! ### L298N デュアルモータドライバ
+//!
+//! | 信号    | ESP32 GPIO | 備考 |
+//! |--------|-----------|------|
+//! | IN1-A  | GPIO 25   | チャンネル A 方向 1 |
+//! | IN2-A  | GPIO 26   | チャンネル A 方向 2 |
+//! | ENA    | GPIO 27   | チャンネル A PWM (LEDC Ch1) |
+//! | IN1-B  | GPIO 32   | チャンネル B 方向 1 |
+//! | IN2-B  | GPIO 33   | チャンネル B 方向 2 |
+//! | ENB    | GPIO 14   | チャンネル B PWM (LEDC Ch2) |
+//!
+//! ### HC-SR04 超音波距離センサ
+//!
+//! | 信号    | ESP32 GPIO | 備考 |
+//! |--------|-----------|------|
+//! | TRIG   | GPIO 5    | 出力 |
+//! | ECHO   | GPIO 4    | 入力（5 V → 3.3 V 分圧推奨） |
+//!
+//! ## ビルド・書き込み
+//!
+//! ```bash
+//! # xtensa ツールチェーン（espup install 済みであること）
+//! cd firmware/original-esp32-robot-base
+//! cargo build --release
+//! cargo run --release   # espflash でフラッシュ + シリアルモニタ
+//! ```
+#![no_std]
+#![no_main]
+
+use esp_backtrace as _;
+use esp_hal::{
+    gpio::{Level, Output, OutputConfig},
+    ledc::{
+        channel::{ChannelConfig, ChannelIFace},
+        timer::{TimerConfig, TimerIFace},
+        LSGlobalClkSource, Ledc, LowSpeed,
+    },
+    main,
+    time::{Duration, Instant},
+};
+use esp_println::println;
+use hal_api::actuator::{DriveMotor, DualMotorDriver, MotorCommand, MotorDirection, ServoMotor};
+use platform_esp32::{
+    gpio::Esp32OutputPin,
+    pwm::Esp32PwmOutput,
+    types::{Esp32L298nChannel, Esp32L298nDualDriverSimple, Esp32ServoDriver},
+};
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+// ── ピン番号定数 ──────────────────────────────────────────────────────────────
+const SERVO_PWM_GPIO: u8 = 18;
+const MOTOR_IN1_A_GPIO: u8 = 25;
+const MOTOR_IN2_A_GPIO: u8 = 26;
+const MOTOR_ENA_GPIO: u8 = 27;
+const MOTOR_IN1_B_GPIO: u8 = 32;
+const MOTOR_IN2_B_GPIO: u8 = 33;
+const MOTOR_ENB_GPIO: u8 = 14;
+
+// ── タイミング定数 ────────────────────────────────────────────────────────────
+/// メインループの周期（1 tick = 20 ms）
+const LOOP_PERIOD_MS: u32 = 20;
+/// デモシーケンスの 1 ステップあたりの tick 数
+const DEMO_STEP_TICKS: u32 = 50; // 50 × 20 ms = 1 s
+
+// ── 型エイリアス（GPIO/LEDC の具体型を指定） ─────────────────────────────────
+// NOTE: `esp_hal::gpio::Output` は `embedded_hal::digital::OutputPin` を実装しており、
+// `esp_hal::ledc::channel::Channel` は `embedded_hal::pwm::SetDutyCycle` を実装している。
+// `Esp32OutputPin<T>` / `Esp32PwmOutput<P>` がそれぞれのラッパーとなる。
+type EspOutput = Output<'static>;
+type EspLedcChannel<'d> = esp_hal::ledc::channel::Channel<'d, LowSpeed>;
+
+// ── デモシーケンス定義 ────────────────────────────────────────────────────────
+#[derive(Clone, Copy)]
+struct DemoStep {
+    servo_angle: u16,
+    motor_duty: u8,
+    direction: MotorDirection,
+}
+
+static DEMO_SEQUENCE: &[DemoStep] = &[
+    DemoStep { servo_angle: 0,   motor_duty: 50, direction: MotorDirection::Forward },
+    DemoStep { servo_angle: 45,  motor_duty: 75, direction: MotorDirection::Forward },
+    DemoStep { servo_angle: 90,  motor_duty: 50, direction: MotorDirection::Brake },
+    DemoStep { servo_angle: 135, motor_duty: 60, direction: MotorDirection::Reverse },
+    DemoStep { servo_angle: 180, motor_duty: 40, direction: MotorDirection::Reverse },
+    DemoStep { servo_angle: 90,  motor_duty: 0,  direction: MotorDirection::Brake },
+];
+
+fn monotonic_delay_ms(ms: u32) {
+    let target = Duration::from_millis(ms as u64);
+    let start = Instant::now();
+    while start.elapsed() < target {}
+}
+
+#[main]
+fn main() -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    // ── GPIO 出力ピンの初期化 ────────────────────────────────────────────────
+    let in1_a: Output<'static> =
+        Output::new(peripherals.GPIO25, Level::Low, OutputConfig::default());
+    let in2_a: Output<'static> =
+        Output::new(peripherals.GPIO26, Level::Low, OutputConfig::default());
+    let in1_b: Output<'static> =
+        Output::new(peripherals.GPIO32, Level::Low, OutputConfig::default());
+    let in2_b: Output<'static> =
+        Output::new(peripherals.GPIO33, Level::Low, OutputConfig::default());
+
+    // ── LEDC（PWM）の初期化 ─────────────────────────────────────────────────
+    let mut ledc = Ledc::new(peripherals.LEDC);
+    ledc.set_global_slow_clock(LSGlobalClkSource::APBClk);
+
+    let mut servo_timer = ledc.timer::<LowSpeed>(esp_hal::ledc::timer::Number::Timer0);
+    servo_timer
+        .configure(TimerConfig {
+            duty: esp_hal::ledc::timer::config::Duty::Duty14Bit,
+            clock_source: esp_hal::ledc::timer::LSClockSource::APBClk,
+            frequency: esp_hal::time::Rate::from_hz(50), // 50 Hz for servo
+        })
+        .unwrap();
+
+    let mut motor_timer = ledc.timer::<LowSpeed>(esp_hal::ledc::timer::Number::Timer1);
+    motor_timer
+        .configure(TimerConfig {
+            duty: esp_hal::ledc::timer::config::Duty::Duty8Bit,
+            clock_source: esp_hal::ledc::timer::LSClockSource::APBClk,
+            frequency: esp_hal::time::Rate::from_hz(1_000), // 1 kHz for motors
+        })
+        .unwrap();
+
+    let mut servo_ch = ledc.channel(
+        esp_hal::ledc::channel::Number::Channel0,
+        peripherals.GPIO18,
+    );
+    servo_ch
+        .configure(ChannelConfig {
+            timer: &servo_timer,
+            duty_pct: 0,
+            pin_config: esp_hal::ledc::channel::config::PinConfig::PushPull,
+        })
+        .unwrap();
+
+    let mut ena_ch = ledc.channel(
+        esp_hal::ledc::channel::Number::Channel1,
+        peripherals.GPIO27,
+    );
+    ena_ch
+        .configure(ChannelConfig {
+            timer: &motor_timer,
+            duty_pct: 0,
+            pin_config: esp_hal::ledc::channel::config::PinConfig::PushPull,
+        })
+        .unwrap();
+
+    let mut enb_ch = ledc.channel(
+        esp_hal::ledc::channel::Number::Channel2,
+        peripherals.GPIO14,
+    );
+    enb_ch
+        .configure(ChannelConfig {
+            timer: &motor_timer,
+            duty_pct: 0,
+            pin_config: esp_hal::ledc::channel::config::PinConfig::PushPull,
+        })
+        .unwrap();
+
+    // ── platform-esp32 ラッパーへの接続 ─────────────────────────────────────
+    let servo_pwm = Esp32PwmOutput::new(servo_ch);
+    let mut servo: Esp32ServoDriver<EspLedcChannel<'_>> = Esp32ServoDriver::new(servo_pwm);
+
+    let ch_a = Esp32L298nChannel::new(
+        Esp32OutputPin::new(in1_a),
+        Esp32OutputPin::new(in2_a),
+        Esp32PwmOutput::new(ena_ch),
+    );
+    let ch_b = Esp32L298nChannel::new(
+        Esp32OutputPin::new(in1_b),
+        Esp32OutputPin::new(in2_b),
+        Esp32PwmOutput::new(enb_ch),
+    );
+    let mut motors: Esp32L298nDualDriverSimple<EspOutput, EspLedcChannel<'_>> =
+        Esp32L298nDualDriverSimple::new(ch_a, ch_b);
+
+    println!("=== ESP32 Robot Base Firmware ===");
+    println!("Servo: GPIO {}", SERVO_PWM_GPIO);
+    println!("Motor A: IN1={} IN2={} ENA={}", MOTOR_IN1_A_GPIO, MOTOR_IN2_A_GPIO, MOTOR_ENA_GPIO);
+    println!("Motor B: IN1={} IN2={} ENB={}", MOTOR_IN1_B_GPIO, MOTOR_IN2_B_GPIO, MOTOR_ENB_GPIO);
+
+    // ── メインループ ─────────────────────────────────────────────────────────
+    let mut tick: u32 = 0;
+    loop {
+        let step_index =
+            ((tick / DEMO_STEP_TICKS) as usize) % DEMO_SEQUENCE.len();
+        let step = &DEMO_SEQUENCE[step_index];
+
+        if tick % DEMO_STEP_TICKS == 0 {
+            println!(
+                "[tick {}] step {} — servo={}° motor={:?}@{}%",
+                tick, step_index, step.servo_angle, step.direction, step.motor_duty
+            );
+
+            if let Err(e) = servo.set_angle_degrees(step.servo_angle) {
+                println!("servo error: {:?}", e);
+            }
+
+            let cmd = MotorCommand::new(step.direction, step.motor_duty as u16);
+            if let Err(e) = motors.apply_channels(cmd, cmd) {
+                println!("motor error: {:?}", e);
+            }
+        }
+
+        tick = tick.wrapping_add(1);
+        monotonic_delay_ms(LOOP_PERIOD_MS);
+    }
+}

--- a/firmware/original-esp32-robot-base/src/main.rs
+++ b/firmware/original-esp32-robot-base/src/main.rs
@@ -23,13 +23,6 @@
 //! | IN2-B  | GPIO 33   | チャンネル B 方向 2 |
 //! | ENB    | GPIO 14   | チャンネル B PWM (LEDC Ch2) |
 //!
-//! ### HC-SR04 超音波距離センサ
-//!
-//! | 信号    | ESP32 GPIO | 備考 |
-//! |--------|-----------|------|
-//! | TRIG   | GPIO 5    | 出力 |
-//! | ECHO   | GPIO 4    | 入力（5 V → 3.3 V 分圧推奨） |
-//!
 //! ## ビルド・書き込み
 //!
 //! ```bash
@@ -63,6 +56,9 @@ use platform_esp32::{
 esp_bootloader_esp_idf::esp_app_desc!();
 
 // ── ピン番号定数 ──────────────────────────────────────────────────────────────
+// NOTE: これらの定数は println! によるログ出力用です。
+//       実際のペリフェラル初期化は peripherals.GPIOxx を直接使用します。
+//       ピン変更時は両方を同時に更新してください。
 const SERVO_PWM_GPIO: u8 = 18;
 const MOTOR_IN1_A_GPIO: u8 = 25;
 const MOTOR_IN2_A_GPIO: u8 = 26;
@@ -95,7 +91,7 @@ struct DemoStep {
 static DEMO_SEQUENCE: &[DemoStep] = &[
     DemoStep { servo_angle: 0,   motor_duty: 50, direction: MotorDirection::Forward },
     DemoStep { servo_angle: 45,  motor_duty: 75, direction: MotorDirection::Forward },
-    DemoStep { servo_angle: 90,  motor_duty: 50, direction: MotorDirection::Brake },
+    DemoStep { servo_angle: 90,  motor_duty: 0,  direction: MotorDirection::Brake },
     DemoStep { servo_angle: 135, motor_duty: 60, direction: MotorDirection::Reverse },
     DemoStep { servo_angle: 180, motor_duty: 40, direction: MotorDirection::Reverse },
     DemoStep { servo_angle: 90,  motor_duty: 0,  direction: MotorDirection::Brake },
@@ -218,7 +214,7 @@ fn main() -> ! {
                 println!("servo error: {:?}", e);
             }
 
-            let cmd = MotorCommand::new(step.direction, step.motor_duty as u16);
+            let cmd = MotorCommand::new(step.direction, step.motor_duty);
             if let Err(e) = motors.apply_channels(cmd, cmd) {
                 println!("motor error: {:?}", e);
             }


### PR DESCRIPTION
## 概要

Issue #98 対応。`firmware/original-esp32-robot-base/` を新規追加します。

## 変更内容

### 新規ファイル

| ファイル | 内容 |
|----------|------|
| `Cargo.toml` | esp-hal 1.0.0 依存、standalone workspace |
| `.cargo/config.toml` | xtensa-esp32-none-elf ターゲット設定 |
| `rust-toolchain.toml` | `esp` チャンネル指定 |
| `src/main.rs` | Servo + L298N 実機制御の骨格実装 |
| `README.md` | 配線表、電源構成、ビルド・書き込み手順 |

### アーキテクチャ

```
esp_hal::ledc::Channel ──→ Esp32PwmOutput ──→ Esp32ServoDriver
esp_hal::gpio::Output  ──→ Esp32OutputPin  ──┐
                                              ├─→ Esp32L298nChannel ──→ Esp32L298nDualDriverSimple
esp_hal::ledc::Channel ──→ Esp32PwmOutput  ──┘
```

`platform_esp32::types` の型エイリアスを実際に esp-hal 型と組み合わせた実装例です。

### デモシーケンス

1秒ごとに以下のステップをループ:
- Step 0: servo=0°, motor=Forward@50%
- Step 1: servo=45°, motor=Forward@75%
- Step 2: servo=90°, motor=Brake@50%
- Step 3: servo=135°, motor=Reverse@60%
- Step 4: servo=180°, motor=Reverse@40%
- Step 5: servo=90°, motor=Brake@0%

## 配線

### サーボ（SG90 等）
| 信号 | GPIO | LEDC | 周波数 |
|------|------|------|--------|
| PWM  | 18   | Ch0  | 50 Hz  |

### L298N デュアルモータ
| 信号 | GPIO | 種別 |
|------|------|------|
| IN1-A | 25 | デジタル出力 |
| IN2-A | 26 | デジタル出力 |
| ENA   | 27 | LEDC Ch1, 1 kHz |
| IN1-B | 32 | デジタル出力 |
| IN2-B | 33 | デジタル出力 |
| ENB   | 14 | LEDC Ch2, 1 kHz |

## テスト・検証方法

```bash
# ワークスペーステスト（影響なし）
cargo test --workspace --all-targets   # 312 tests
cargo clippy --workspace --all-targets -- -D warnings
```

firmware は standalone workspace のため CI には含まれません（xtensa ツールチェーンが必要なため）。

## 関連

- Closes #98
- 参照: `crates/platform-esp32/types.rs`（型エイリアス定義）
- 参照: `firmware/original-esp32-climate-display/`（I2C センサー版）