### PR TITLE
feat(scripts): add flash-esp32.sh one-command ESP32 flash script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -142,6 +142,55 @@ cargo install espflash
 
 ---
 
+### `gh-workflow.sh` - GitHub ワークフロー操作
+
+`scripts/gh-workflow.sh` で push / PR / Issue 操作を行います。詳細は `gh-workflow.sh --help` を参照してください。
+
+---
+
+### `flash-esp32.sh` - ESP32 ワンコマンドフラッシュ
+
+ファームウェアディレクトリを指定して、ビルド → シリアルポート自動検出 → フラッシュ + モニタを一コマンドで実行します。
+
+**基本的な使用方法:**
+
+```bash
+./scripts/flash-esp32.sh <firmware-dir> [port]
+```
+
+**例:**
+
+```bash
+# シリアルポートを自動検出してフラッシュ
+./scripts/flash-esp32.sh firmware/original-esp32-robot-base
+
+# ポートを明示指定
+./scripts/flash-esp32.sh firmware/original-esp32-climate-display /dev/ttyUSB0
+
+# 環境変数でポート指定
+ESP32_PORT=/dev/cu.usbserial-0001 ./scripts/flash-esp32.sh firmware/original-esp32-robot-base
+```
+
+**自動検出されるシリアルポート:**
+
+| OS | 検索パターン |
+|----|-------------|
+| macOS | `/dev/cu.usbserial-*`, `/dev/cu.SLAB_USBtoUART*`, `/dev/cu.wchusbserial*` |
+| Linux | `/dev/ttyUSB0`, `/dev/ttyUSB1`, `/dev/ttyACM0` |
+| WSL2 | 環境変数 `ESP32_PORT` に COM ポート指定、または `espflash.exe` を直接使用 |
+
+**必要なツール:**
+
+```bash
+# espflash のインストール
+cargo install espflash
+
+# xtensa ツールチェーンのインストール（ESP32 Xtensa 用）
+cargo install espup && espup install
+```
+
+---
+
 ### sim-to-real 開発サイクル
 
 ```bash

--- a/scripts/flash-esp32.sh
+++ b/scripts/flash-esp32.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# flash-esp32.sh — ESP32 ファームウェアのワンコマンドフラッシュスクリプト
+#
+# 使用方法:
+#   ./scripts/flash-esp32.sh <firmware-dir> [port]
+#
+# 引数:
+#   firmware-dir  ファームウェアのディレクトリ (例: firmware/original-esp32-robot-base)
+#   port          シリアルポート (省略時は自動検出)
+#
+# 例:
+#   ./scripts/flash-esp32.sh firmware/original-esp32-robot-base
+#   ./scripts/flash-esp32.sh firmware/original-esp32-climate-display /dev/ttyUSB0
+#
+# 依存ツール:
+#   espflash  (cargo install espflash)
+#   esp       xtensa ツールチェーン (espup install)
+#
+# シリアルポート自動検出:
+#   macOS: /dev/cu.usbserial-* または /dev/cu.SLAB_USBtoUART* または /dev/cu.wchusbserial*
+#   Linux: /dev/ttyUSB0, /dev/ttyUSB1, /dev/ttyACM0
+#   WSL2 + Windows: 環境変数 ESP32_PORT に COM ポートを指定するか
+#                   espflash.exe をフルパスで使用してください
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ── 引数チェック ───────────────────────────────────────────────────────────────
+if [[ $# -lt 1 ]]; then
+    echo -e "${CYAN}使用方法:${NC} $0 <firmware-dir> [port]"
+    echo ""
+    echo "  firmware-dir   ファームウェアのディレクトリ"
+    echo "                 例: firmware/original-esp32-robot-base"
+    echo "                     firmware/original-esp32-climate-display"
+    echo "  port           シリアルポート（省略時は自動検出）"
+    echo ""
+    echo "例:"
+    echo "  $0 firmware/original-esp32-robot-base"
+    echo "  $0 firmware/original-esp32-climate-display /dev/ttyUSB0"
+    exit 1
+fi
+
+FIRMWARE_DIR="${1}"
+MANUAL_PORT="${2:-}"
+
+# ── ファームウェアディレクトリ確認 ─────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIRMWARE_PATH="${REPO_ROOT}/${FIRMWARE_DIR}"
+
+if [[ ! -d "${FIRMWARE_PATH}" ]]; then
+    log_error "ファームウェアディレクトリが見つかりません: ${FIRMWARE_PATH}"
+    exit 1
+fi
+
+if [[ ! -f "${FIRMWARE_PATH}/Cargo.toml" ]]; then
+    log_error "Cargo.toml が見つかりません: ${FIRMWARE_PATH}/Cargo.toml"
+    exit 1
+fi
+
+# ── espflash 確認 ──────────────────────────────────────────────────────────────
+if ! command -v espflash &>/dev/null; then
+    log_error "espflash が見つかりません。以下でインストールしてください:"
+    echo "    cargo install espflash"
+    exit 1
+fi
+log_ok "espflash: $(espflash --version 2>&1 | head -1)"
+
+# ── シリアルポート検出 ─────────────────────────────────────────────────────────
+detect_port() {
+    local port=""
+
+    # 環境変数で指定されている場合はそれを使用
+    if [[ -n "${ESP32_PORT:-}" ]]; then
+        echo "${ESP32_PORT}"
+        return
+    fi
+
+    # macOS: /dev/cu.usbserial-*, /dev/cu.SLAB_USBtoUART*, /dev/cu.wchusbserial*
+    if [[ "$(uname)" == "Darwin" ]]; then
+        for pattern in \
+            "/dev/cu.usbserial-*" \
+            "/dev/cu.SLAB_USBtoUART*" \
+            "/dev/cu.wchusbserial*" \
+            "/dev/cu.usbmodem*"; do
+            # shellcheck disable=SC2086
+            port="$(ls ${pattern} 2>/dev/null | head -1)"
+            if [[ -n "${port}" ]]; then
+                echo "${port}"
+                return
+            fi
+        done
+    fi
+
+    # Linux: /dev/ttyUSB*, /dev/ttyACM*
+    if [[ "$(uname)" == "Linux" ]]; then
+        for device in /dev/ttyUSB0 /dev/ttyUSB1 /dev/ttyACM0 /dev/ttyACM1; do
+            if [[ -e "${device}" ]]; then
+                echo "${device}"
+                return
+            fi
+        done
+    fi
+
+    echo ""
+}
+
+if [[ -n "${MANUAL_PORT}" ]]; then
+    PORT="${MANUAL_PORT}"
+    log_info "シリアルポート（指定）: ${PORT}"
+else
+    PORT="$(detect_port)"
+    if [[ -z "${PORT}" ]]; then
+        log_warn "シリアルポートを自動検出できませんでした。"
+        log_warn "ESP32 を接続してから再試行するか、ポートを明示的に指定してください:"
+        echo "    $0 ${FIRMWARE_DIR} /dev/cu.usbserial-XXXX   # macOS"
+        echo "    $0 ${FIRMWARE_DIR} /dev/ttyUSB0              # Linux"
+        echo "    ESP32_PORT=/dev/ttyUSB0 $0 ${FIRMWARE_DIR}  # 環境変数"
+        exit 1
+    fi
+    log_ok "シリアルポート（自動検出）: ${PORT}"
+fi
+
+# ── ビルド ──────────────────────────────────────────────────────────────────────
+log_info "ビルド中: ${FIRMWARE_DIR}"
+cd "${FIRMWARE_PATH}"
+cargo build --release
+log_ok "ビルド完了"
+
+# ── フラッシュ + モニタ ─────────────────────────────────────────────────────────
+log_info "フラッシュ中: ${PORT}"
+echo -e "${CYAN}------------------------------------------------------------------${NC}"
+echo -e "${CYAN}  Ctrl+C でモニタを終了します${NC}"
+echo -e "${CYAN}------------------------------------------------------------------${NC}"
+espflash flash --port "${PORT}" --monitor --release


### PR DESCRIPTION
## 概要

Issue #102 対応。`scripts/flash-esp32.sh` を追加します。ファームウェアディレクトリを指定するだけでビルド → シリアルポート自動検出 → フラッシュ + モニタが一コマンドで完了します。

## 変更内容

### `scripts/flash-esp32.sh` （新規）

| 機能 | 内容 |
|------|------|
| ポート自動検出（macOS） | `/dev/cu.usbserial-*`, `/dev/cu.SLAB_USBtoUART*`, `/dev/cu.wchusbserial*` |
| ポート自動検出（Linux） | `/dev/ttyUSB0/1`, `/dev/ttyACM0/1` |
| 環境変数対応 | `ESP32_PORT` で明示的に指定可能 |
| 引数指定 | `$2` にポートを直接渡せる |
| バリデーション | ファームウェアディレクトリ・Cargo.toml・espflash の存在確認 |
| ビルド | `cargo build --release` をファームウェアディレクトリで実行 |
| フラッシュ | `espflash flash --port $PORT --monitor --release` |

### `scripts/README.md` （更新）

`flash-esp32.sh` の使用方法・自動検出パターン一覧・WSL2 代替手順を追記。

## 使用方法

```bash
# ポート自動検出
./scripts/flash-esp32.sh firmware/original-esp32-robot-base

# ポート指定
./scripts/flash-esp32.sh firmware/original-esp32-climate-display /dev/ttyUSB0

# 環境変数
ESP32_PORT=/dev/cu.usbserial-0001 ./scripts/flash-esp32.sh firmware/original-esp32-robot-base
```

## 検証方法

```bash
# シンタックス確認
bash -n scripts/flash-esp32.sh

# ヘルプ表示
./scripts/flash-esp32.sh   # usage を表示して exit 1

# ディレクトリ不在テスト
./scripts/flash-esp32.sh nonexistent/dir   # エラーメッセージを表示して exit 1
```

## 関連

- Closes #102