### PR TITLE
docs: update climate-display README with flash-esp32.sh reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.17] - 2026-05-10
+
+### Changed
+- `firmware/original-esp32-climate-display/README.md`: updated flash instructions to reference
+  `scripts/flash-esp32.sh` for one-command flash with auto port detection; updated confirmation
+  scope to include macOS/Linux port auto-detection and WSL2 notes
+
+---
+
 ## [0.3.15] - 2026-05-07
 
 ### Added

--- a/firmware/original-esp32-climate-display/README.md
+++ b/firmware/original-esp32-climate-display/README.md
@@ -32,6 +32,12 @@ original ESP32 + `BME280` + `LCD1602` I2C backpack 向けの climate display fir
 ## 実行
 
 ```bash
+# ワークスペースルートから scripts/flash-esp32.sh を使う場合（推奨）
+cd /path/to/mcu-hal-sim-rs
+./scripts/flash-esp32.sh original-esp32-climate-display      # ポート自動検出
+./scripts/flash-esp32.sh original-esp32-climate-display /dev/cu.usbserial-0001  # ポート明示
+
+# または firmware ディレクトリ内で直接実行する場合
 cd firmware/original-esp32-climate-display
 
 # Xtensa toolchain が入っている環境ならそのまま
@@ -58,7 +64,9 @@ climate refresh tick=10 temp_cc=2481 hum_cp=4315 line1="Temp    24.8C   " line2=
 - host 側の `cargo test --workspace --all-targets`
 - host 側の `cargo clippy --workspace --all-targets -- -D warnings`
 - この crate の `cargo build --release`
-- Windows `espflash.exe` 経由の actual flash
+- `scripts/flash-esp32.sh original-esp32-climate-display` による one-command flash
+- macOS: `/dev/cu.*` の自動検出、Linux: `/dev/ttyUSB*` の自動検出
+- Windows WSL2 環境では `espflash.exe` 経由でのポート指定 flash
 - original ESP32 + `BME280` + `LCD1602` で温湿度表示を実機確認
 - 実機シリアルで `climate refresh tick = ...` の継続出力を確認
 


### PR DESCRIPTION
## 概要

Issue #103 の対応として、`firmware/original-esp32-climate-display/README.md` を更新しました。

## 変更内容

### `firmware/original-esp32-climate-display/README.md`
- 実行手順を `scripts/flash-esp32.sh` による one-command flash を優先する形に更新
  - macOS: `/dev/cu.*` 自動検出
  - Linux: `/dev/ttyUSB*` 自動検出
  - ポート明示オプション例を追加
- この branch での確認範囲に `flash-esp32.sh`、macOS/Linux ポート検出、WSL2 代替経路を明記

### `CHANGELOG.md`
- v0.3.17 エントリを追加

## なお

firmware の本体実装（main.rs）は既に完成状態でした。`ClimateDisplayApp` による BME280 読み取り・LCD1602 16x2 表示・シリアルログ出力はすべて実装済みです。

## テスト

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

all pass ✅

Closes #103