### PR TITLE
docs: update robot-base README with flash-esp32.sh reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.18] - 2026-05-10
+
+### Changed
+- `firmware/original-esp32-robot-base/README.md`: updated flash instructions to reference
+  `scripts/flash-esp32.sh`; added macOS/Linux/WSL2 port detection notes
+
+---
+
 ## [0.3.17] - 2026-05-10
 
 ### Changed

--- a/firmware/original-esp32-robot-base/README.md
+++ b/firmware/original-esp32-robot-base/README.md
@@ -68,17 +68,25 @@ cargo install espflash
 ## ビルドと書き込み
 
 ```bash
+# ワークスペースルートから scripts/flash-esp32.sh を使う場合（推奨）
+cd /path/to/mcu-hal-sim-rs
+./scripts/flash-esp32.sh original-esp32-robot-base           # ポート自動検出
+./scripts/flash-esp32.sh original-esp32-robot-base /dev/cu.usbserial-0001  # ポート明示
+
+# または firmware ディレクトリ内で直接実行する場合
 cd firmware/original-esp32-robot-base
 
 # ビルドのみ
 cargo build --release
 
-# フラッシュ書き込み + シリアルモニタ（macOS: /dev/tty.usbserial-*）
+# フラッシュ書き込み + シリアルモニタ（macOS: /dev/cu.*）
 cargo run --release
-
-# デバイスを明示指定する場合
-espflash flash --port /dev/tty.usbserial-0001 target/xtensa-esp32-none-elf/release/original-esp32-robot-base --monitor
 ```
+
+`flash-esp32.sh` はポートを自動検出します:
+- macOS: `/dev/cu.usbserial-*`, `/dev/cu.SLAB_*`, `/dev/cu.wchusbserial-*` 等
+- Linux: `/dev/ttyUSB*`, `/dev/ttyACM*`
+- WSL2: `espflash.exe` 経由で Windows COM ポートを使用（`ESP32_PORT=COM3 ./scripts/flash-esp32.sh ...`）
 
 ## 期待される出力
 


### PR DESCRIPTION
## 概要

Issue #108 の対応。`firmware/original-esp32-robot-base/README.md` の flash 手順を `scripts/flash-esp32.sh` を優先する形に更新しました。

## 変更内容

### `firmware/original-esp32-robot-base/README.md`
- `scripts/flash-esp32.sh` による one-command flash を推奨手順として追加
  - macOS: `/dev/cu.*` 自動検出
  - Linux: `/dev/ttyUSB*` 自動検出
  - WSL2: `ESP32_PORT=COM3` 経由
- 直接 `espflash` コマンドは削除し、 `cargo run --release` との選択肢を明示

### `CHANGELOG.md`
- v0.3.18 エントリを追加

## テスト

```bash
cargo test --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

all pass ✅

Closes #108