### PR TITLE
fix(platform-avr): align test std import with cfg(test) extern crate std convention

### DIFF
--- a/crates/platform-avr/tests/app_bridge.rs
+++ b/crates/platform-avr/tests/app_bridge.rs
@@ -1,4 +1,7 @@
 use core::convert::Infallible;
+
+#[cfg(test)]
+extern crate std;
 use std::cell::RefCell;
 use std::rc::Rc;
 


### PR DESCRIPTION
## 概要

Issue #112 の対応。`tests/app_bridge.rs` の `use std::...` をワークスペース共通の `#[cfg(test)] extern crate std` パターンへ統一しました。

## 変更内容

### `crates/platform-avr/tests/app_bridge.rs`
- 裸の `use std::cell::RefCell; use std::rc::Rc;` を `#[cfg(test)] extern crate std;` の下に移動
- `hal-api`、`core-app`、`reference-drivers` のテストと同じ規約に統一

## テスト

```bash
cargo test -p platform-avr  # 8 tests pass
cargo clippy -p platform-avr --all-targets -- -D warnings
```

Closes #112