### PR TITLE
feat(arduino): wire arduino-nano-bringup through AvrOutputPin/AvrI2c/core-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `firmware/arduino-nano-bringup/src/main.rs`: wired through `platform-avr` adapters
+  (`AvrOutputPin`, `AvrI2c`) and `core-app::App`; I2C scan still runs at startup, then
+  `App::tick()` drives the main loop via `hal-api` contract
+- `firmware/arduino-nano-bringup/Cargo.toml`: added `platform-avr` and `core-app` path deps
+- `firmware/arduino-nano-bringup/README.md`: updated to document the sim-to-real wiring and
+  startup sequence
+
 ---
 
 ## [0.3.20] - 2026-05-10

--- a/firmware/arduino-nano-bringup/Cargo.toml
+++ b/firmware/arduino-nano-bringup/Cargo.toml
@@ -18,6 +18,8 @@ ufmt = "0.2.0"
 nb = "1.1.0"
 embedded-hal = "1.0"
 arduino-hal = { git = "https://github.com/rahix/avr-hal", rev = "e5c8f37fe48419956e722490a82b9ca9b9fc61a2", features = ["arduino-nano"] }
+platform-avr = { path = "../../crates/platform-avr" }
+core-app = { path = "../../crates/core-app", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/firmware/arduino-nano-bringup/README.md
+++ b/firmware/arduino-nano-bringup/README.md
@@ -2,20 +2,23 @@
 
 classic Arduino Nano (`ATmega328P`) 向けの bring-up firmware です。
 
-この crate は、`mcu-hal-sim-rs` が今後 `Arduino Nano` 系まで広がることを見据えた最初の実機足場です。  
-現時点では `core-app` との統合より前に、次の 3 点を最短で確認する目的に絞っています。
+この crate は `mcu-hal-sim-rs` の sim-to-real 経路を AVR 系 board まで伸ばす最初の実機足場です。  
+`platform-avr` の `AvrOutputPin` / `AvrI2c` アダプタを通して `core-app::App` を実行することで、  
+PC シミュレータと同じアプリロジックを Arduino Nano 実機上で動作させます。
 
-- onboard LED (`D13`) の点滅
-- USB serial の疎通
-- onboard I2C (`A4` / `A5`) にぶら下がる sensor の address 検出
+## 起動シーケンス
+
+1. `scan_i2c_bus` で A4/A5 に繋がる sensor address を検出し serial に出力
+2. `arduino_hal` の pin / I2C を `platform-avr` アダプタでラップ
+3. `App::new(avr_pin, avr_i2c)` で `core-app` を生成し、`app.tick()` ループへ
 
 ## 対象
 
 - board: classic Arduino Nano
 - MCU: `ATmega328P`
-- LED: `D13`
+- LED: `D13` (`AvrOutputPin` でラップ)
 - I2C:
-  - `A4` -> `SDA`
+  - `A4` -> `SDA` (`AvrI2c` でラップ)
   - `A5` -> `SCL`
 
 ## 前提
@@ -61,21 +64,31 @@ cargo run --release
 
 ## ログで確認すること
 
-- `arduino nano bring-up started`
+- `arduino nano bring-up + hal-api demo`
 - `LED=D13 SDA=A4 SCL=A5 ...`
 - `Write direction test:` / `Read direction test:` の I2C detect 結果
-- `heartbeat=...`
+- `Starting core-app via hal-api adapters...`
+- `heartbeat=...` — `core-app::App::tick()` が 100 tick ごとに LED を制御
 
-40 heartbeat ごとに I2C bus を再 scan します。  
-新しい sensor を足す前に、まずこの firmware で address が見えることを確認してください。
+## コード構成
+
+```
+arduino-nano-bringup/src/main.rs
+ ├─ scan_i2c_bus()        : 起動時の I2C bus scan (arduino_hal 直接)
+ ├─ AvrOutputPin::new(led): D13 を hal-api OutputPin でラップ
+ ├─ AvrI2c::new(i2c)     : TWI を hal-api I2cBus でラップ
+ └─ App::new(pin, i2c)   : platform 非依存のアプリロジック実行
+```
 
 ## この crate の位置づけ
 
-- これは `platform-avr` や `core-app` 連携の前段です
-- まず board 固有の bring-up を固定し、その後に共通 contract へ還流する方針です
-- `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` も同じ考え方で、最初は bring-up firmware から始めます
+- `platform-avr` (`AvrOutputPin` / `AvrI2c`) と `core-app` の統合を実機で示す
+- PC シミュレータ (`platform-pc-sim`) と同じ `App` 型をそのまま再利用
+- board 固有の初期化 (`arduino_hal` 呼び出し) はこの firmware に閉じ込め、`platform-avr` を汚染しない
 
 ## 未検証事項
 
-- この環境では AVR toolchain が未導入のため、`cargo run --release` の実機検証は未実施です
+- この環境では AVR toolchain が未導入のため、`cargo run --release` の実機検証は未実施
 - 旧 bootloader / clone board では `ravedude` の board 指定や baud を調整する必要があります
+- `arduino_hal::I2c` の `embedded-hal v1.0` 対応は avr-hal commit `e5c8f37` 以降に依存します
+

--- a/firmware/arduino-nano-bringup/src/main.rs
+++ b/firmware/arduino-nano-bringup/src/main.rs
@@ -2,7 +2,9 @@
 #![no_main]
 
 use arduino_hal::prelude::*;
+use core_app::App;
 use panic_halt as _;
+use platform_avr::{gpio::AvrOutputPin, i2c::AvrI2c};
 use ufmt::uWrite;
 
 const SERIAL_BAUD: u32 = 57_600;
@@ -28,7 +30,7 @@ fn main() -> ! {
     let pins = arduino_hal::pins!(dp);
 
     let mut serial = arduino_hal::default_serial!(dp, pins, SERIAL_BAUD);
-    let mut led = pins.d13.into_output();
+    let led = pins.d13.into_output();
     let mut i2c = arduino_hal::I2c::new(
         dp.TWI,
         pins.a4.into_pull_up_input(),
@@ -36,7 +38,7 @@ fn main() -> ! {
         I2C_FREQUENCY_HZ,
     );
 
-    ufmt::uwriteln!(serial, "arduino nano bring-up started\r").unwrap_infallible();
+    ufmt::uwriteln!(serial, "arduino nano bring-up + hal-api demo\r").unwrap_infallible();
     ufmt::uwriteln!(
         serial,
         "LED=D13 SDA=A4 SCL=A5 baud={} i2c={}Hz\r",
@@ -52,18 +54,24 @@ fn main() -> ! {
 
     scan_i2c_bus(&mut serial, &mut i2c);
 
+    // Wrap arduino-hal types into platform-avr hal-api adapters and run core-app.
+    let avr_pin = AvrOutputPin::new(led);
+    let avr_i2c = AvrI2c::new(i2c);
+    let mut app = App::new(avr_pin, avr_i2c);
+
+    ufmt::uwriteln!(serial, "Starting core-app via hal-api adapters...\r").unwrap_infallible();
+
     let mut heartbeat = 0u32;
     loop {
         heartbeat = heartbeat.wrapping_add(1);
-        led.toggle();
+
+        if let Err(_) = app.tick() {
+            ufmt::uwriteln!(serial, "app.tick() error at heartbeat={}\r", heartbeat)
+                .unwrap_infallible();
+        }
 
         if heartbeat % 4 == 0 {
             ufmt::uwriteln!(serial, "heartbeat={}\r", heartbeat).unwrap_infallible();
-        }
-
-        if heartbeat % 40 == 0 {
-            ufmt::uwriteln!(serial, "rescanning I2C bus...\r").unwrap_infallible();
-            scan_i2c_bus(&mut serial, &mut i2c);
         }
 
         arduino_hal::delay_ms(HEARTBEAT_DELAY_MS);


### PR DESCRIPTION
## 概要

Issue #110 の対応です。`arduino-nano-bringup` を `platform-avr` アダプタ経由で `core-app` に接続し、sim-to-real 経路を固定しました。

## 変更内容

### `firmware/arduino-nano-bringup/Cargo.toml`
- `platform-avr` / `core-app` のパス依存を追加（`core-app` は `default-features = false`）

### `firmware/arduino-nano-bringup/src/main.rs`
- 起動時: `scan_i2c_bus` で A4/A5 の I2C address を `arduino_hal` で検出（従来通り）
- その後: `led` → `AvrOutputPin::new(led)`, `i2c` → `AvrI2c::new(i2c)` でラップ
- `App::new(avr_pin, avr_i2c)` を生成して `app.tick()` ループへ移行
- エラーは serial にログ出力

### `firmware/arduino-nano-bringup/README.md`
- 起動シーケンス・コード構成・位置づけを更新

## 動作確認方法

AVR toolchain が必要です（avr-gcc + ravedude）:

```bash
cd firmware/arduino-nano-bringup
cargo run --release
```

シリアルログで確認:
- `arduino nano bring-up + hal-api demo`
- `Starting core-app via hal-api adapters...`
- `heartbeat=...`

## 注意事項

- ホスト環境に AVR toolchain がないため CI での自動ビルドは対象外
- `arduino_hal::I2c` の embedded-hal v1.0 対応は avr-hal commit `e5c8f37` 以降に依存

Closes #110