### PR TITLE
test(reference-path): cover i2c error cases

### DIFF
--- a/crates/platform-esp32/shared_i2c.rs
+++ b/crates/platform-esp32/shared_i2c.rs
@@ -78,6 +78,29 @@ mod tests {
         }
     }
 
+    struct FailingI2c;
+
+    impl I2cBus for FailingI2c {
+        type Error = I2cError;
+
+        fn write(&mut self, _addr: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+
+        fn read(&mut self, _addr: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _bytes: &[u8],
+            _buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+    }
+
     #[test]
     fn shared_i2c_bus_allows_multiple_handles() {
         let inner = RefCell::new(DummyI2c::default());
@@ -94,5 +117,19 @@ mod tests {
             &[(0x27, vec![0x01]), (0x77, vec![0xF7])]
         );
         assert_eq!(buffer, [0xAA, 0xAA]);
+    }
+
+    #[test]
+    fn shared_i2c_bus_propagates_inner_bus_errors() {
+        let inner = RefCell::new(FailingI2c);
+        let mut bus = SharedI2cBus::new(&inner);
+        let mut buffer = [0u8; 2];
+
+        assert_eq!(bus.write(0x27, &[0x01]), Err(I2cError::Timeout));
+        assert_eq!(bus.read(0x27, &mut buffer), Err(I2cError::Timeout));
+        assert_eq!(
+            bus.write_read(0x77, &[0xF7], &mut buffer),
+            Err(I2cError::Timeout)
+        );
     }
 }

--- a/crates/reference-drivers/bme280.rs
+++ b/crates/reference-drivers/bme280.rs
@@ -385,6 +385,31 @@ mod tests {
         }
     }
 
+    struct FailingI2c {
+        error: I2cError,
+    }
+
+    impl I2cBus for FailingI2c {
+        type Error = I2cError;
+
+        fn write(&mut self, _addr: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
+            Err(self.error.clone())
+        }
+
+        fn read(&mut self, _addr: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+            Err(self.error.clone())
+        }
+
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _bytes: &[u8],
+            _buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            Err(self.error.clone())
+        }
+    }
+
     #[test]
     fn sign_extend_12_handles_positive_and_negative_values() {
         assert_eq!(sign_extend_12(0x07F), 127);
@@ -414,6 +439,20 @@ mod tests {
     }
 
     #[test]
+    fn bme280_sensor_maps_i2c_errors_to_sensor_errors() {
+        for (i2c_error, sensor_error) in [
+            (I2cError::InvalidAddress, SensorError::NotInitialized),
+            (I2cError::Timeout, SensorError::Busy),
+            (I2cError::BusError, SensorError::BusError),
+        ] {
+            let mut sensor = Bme280Sensor::new(FailingI2c { error: i2c_error });
+
+            assert_eq!(sensor.read(), Err(sensor_error));
+            assert!(!sensor.is_initialized());
+        }
+    }
+
+    #[test]
     fn bme280_sensor_rejects_unexpected_chip_id() {
         let bus = RecordingI2c::default();
         bus.set_response(REG_CHIP_ID, &[0x00]);
@@ -432,6 +471,21 @@ mod tests {
 
         assert!(reading.temperature_centi_celsius > 0);
         assert!(reading.humidity_centi_percent <= 10_000);
+    }
+
+    #[test]
+    fn bme280_sensor_returns_last_completed_sample_while_measuring_invalid_sample() {
+        let bus = RecordingI2c::with_bme280_defaults();
+        let mut sensor = Bme280Sensor::new(bus.clone());
+        let last_reading = sensor.read().unwrap();
+
+        bus.set_response(REG_STATUS, &[0x01]);
+        bus.set_response(
+            REG_PRESS_MSB,
+            &[0x65, 0x5A, 0xC0, 0x80, 0x00, 0x00, 0x80, 0x00],
+        );
+
+        assert_eq!(sensor.read(), Ok(last_reading));
     }
 
     #[test]

--- a/crates/reference-drivers/lcd1602.rs
+++ b/crates/reference-drivers/lcd1602.rs
@@ -383,6 +383,22 @@ mod tests {
     }
 
     #[test]
+    fn lcd1602_display_reports_data_write_failure_after_initialization() {
+        let bus = RecordingI2c::default();
+        let fail_after_writes = bus.fail_after_writes.clone();
+        let delay = DummyDelay::default();
+        let mut display = Lcd1602Display::new(bus, delay);
+        let frame = TextFrame16x2::from_lines("Line 1", "Line 2");
+
+        display.render(&frame).unwrap();
+        assert!(display.is_initialized());
+        *fail_after_writes.borrow_mut() = Some(0);
+
+        assert_eq!(display.render(&frame), Err(DisplayError::BusError));
+        assert!(display.is_initialized());
+    }
+
+    #[test]
     fn lcd1602_display_accepts_custom_config() {
         let bus = RecordingI2c::default();
         let delay = DummyDelay::default();


### PR DESCRIPTION
## Summary
- Add BME280 tests for I2C error-to-sensor error mapping
- Cover BME280 fallback to the last completed sample while conversion is busy and the raw sample is invalid
- Add LCD1602 coverage for data write failures after initialization
- Add SharedI2cBus coverage for propagating inner bus errors

## Test Plan
- [x] cargo fmt --all -- --check
- [x] cargo test -p reference-drivers bme280
- [x] cargo test -p reference-drivers lcd1602
- [x] cargo test -p platform-esp32 shared_i2c
- [x] cargo clippy --all --all-targets -- -D warnings
- [x] cargo test --workspace --all-targets

AI review: passed; addressed non-blocking buffer-contract concern.