### PR TITLE
docs: sync CLAUDE.md and PLAN.md to current reference path state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,536 +1,237 @@
 # CLAUDE.md - mcu-hal-sim-rs
 
-このファイルは、`mcu-hal-sim-rs` プロジェクト固有のガイドラインを提供します。
-
-**共通の開発方針**（TDD、Git運用、PR作成ルールなど）は `/home/takeshi_miura/workspace/CLAUDE.md` を参照してください。
-
----
+このファイルは、`mcu-hal-sim-rs` プロジェクト固有の開発コンテキストを提供します。
 
 ## プロジェクト概要
 
-`mcu-hal-sim-rs`は、ESP32/Arduino Nano/Raspberry Pi Pico等のマイコン向けRustアプリケーションを、MCU非依存のHAL trait経由で記述し、PC上のシミュレータで動作確認できるようにするプロジェクトです。
+`mcu-hal-sim-rs` は、マイコン向け Rust アプリケーションを **MCU 非依存の HAL trait 経由で記述し、PC simulator で検証してから実機へ持っていくための基盤 repo** です。
 
-### 開発目標
-- ✅ **Phase 1**: PCシミュレータの完成（hal-api、core-app、platform-pc-sim）
-- ✅ **Phase 2**: テスト基盤の整備（59テスト）
-- ✅ **Phase 3**: CI/CD環境の構築
-- 🚧 **Phase 4**: `no_std` 対応とESP32実機準備
-  - `hal-api` と `core-app` は `no_std` 対応済み
-  - 次は `platform-esp32` の骨組みと `no_std` 検証のCI化
+現在の reference path は次です。
 
----
+```text
+platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD1602
+```
+
+この repo では `hal-api` / `core-app` / `reference-drivers` / `platform-*` の責務分離と、sim-to-real 契約の固定を優先します。`M5StickC` は補助診断ボード、`Arduino Nano` / `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` は将来候補または別 repo 先行の拡張候補として扱います。
+
+## 現在のフェーズ
+
+- ✅ PC simulator / core HAL trait / app logic の基盤
+- ✅ CI/CD と workspace test / clippy / format / no_std check
+- ✅ `hal-api` と `core-app` の `no_std` 維持
+- ✅ `platform-esp32` の adapter 層と original ESP32 bring-up firmware
+- ✅ `ClimateDisplayApp` の PC simulator と original ESP32 climate display reference path
+- ✅ BME280 / LCD1602 / SharedI2cBus の基本・異常系テスト
+- 🚧 Phase 4: no_std 対応と original ESP32 実機確認手順の維持・拡張
+
+## スコープ方針
+
+### 本 repo に残すもの
+
+- `hal-api` の汎用抽象
+- `core-app` の再利用可能なアプリロジック
+- `reference-drivers` の board 非依存 driver
+- `platform-pc-sim` / `platform-avr` / `platform-esp32` の sim-to-real 経路
+- original ESP32 + BME280 + LCD1602 の本線シナリオ
+- 共通化価値がある sensor / display / actuator 契約とテスト
+
+### 本 repo に先に入れないもの
+
+- 特定 board だけで完結する実験的 UI
+- camera / wireless / board 固有周辺機能の寄せ集め
+- 個別プロダクト向けアプリ要件そのもの
+
+特に `ESP32-CAM` は camera / framebuffer / board 固有配線を含むため、まず別 repo で進め、必要になった最小抽象だけを本 repo に還流します。
 
 ## プロジェクト構成
 
-```
+```text
 mcu-hal-sim-rs/
 ├── crates/
-│   ├── hal-api/          # HAL trait定義（GPIO、I2C等）
-│   │   ├── error.rs      # GpioError、I2cError
-│   │   ├── gpio.rs       # OutputPin、InputPin trait
-│   │   ├── i2c.rs        # I2cBus trait
-│   │   └── lib.rs        # モジュールルート
+│   ├── hal-api/             # HAL trait / common error types
+│   │   ├── actuator.rs      # ServoMotor / DriveMotor / DualMotorDriver
+│   │   ├── camera.rs        # CameraCapture / FrameMetadata
+│   │   ├── distance.rs      # DistanceSensor
+│   │   ├── display.rs       # TextDisplay16x2 / TextFrame16x2
+│   │   ├── error.rs         # GPIO / I2C / sensor / display / actuator errors
+│   │   ├── gpio.rs          # OutputPin / InputPin
+│   │   ├── i2c.rs           # I2cBus
+│   │   ├── imu.rs           # ImuSensor
+│   │   └── sensor.rs        # EnvSensor / EnvReading
 │   │
-│   ├── core-app/         # アプリケーションロジック（プラットフォーム非依存）
-│   │   └── lib.rs        # App<PIN, I2C>構造体
-│   │                     # - 100 tickごとのLED点滅
-│   │                     # - 500 tickごとのI2C読み取り
+│   ├── core-app/            # platform 非依存 app logic
+│   │   ├── climate_display.rs # ClimateDisplayApp
+│   │   ├── imu_logger.rs
+│   │   └── lib.rs             # App<PIN, I2C>
 │   │
-│   ├── platform-pc-sim/  # PCシミュレータ実装
-│   │   ├── lib.rs        # モックHALの公開
-│   │   ├── main.rs       # 10ms tickループ
-│   │   └── mock_hal.rs   # MockPin、MockI2c実装
+│   ├── reference-drivers/   # board 非依存 reference drivers
+│   │   ├── bme280.rs
+│   │   ├── lcd1602.rs
+│   │   ├── hc_sr04.rs
+│   │   ├── mpu6050.rs
+│   │   ├── sgp30.rs
+│   │   ├── ssd1306.rs
+│   │   ├── vl53l0x.rs
+│   │   ├── servo.rs
+│   │   └── l298n.rs
 │   │
-│   └── platform-esp32/   # ESP32実装（Week 7-8で実装予定）
-│       └── (未実装)
+│   ├── platform-pc-sim/     # host simulator / mocks / dashboards
+│   │   ├── virtual_i2c.rs
+│   │   ├── bme280_mock.rs
+│   │   ├── lcd1602_mock.rs
+│   │   ├── climate_sim.rs
+│   │   ├── climate_display_sim.rs
+│   │   ├── climate_dashboard_sim.rs
+│   │   ├── component_sim.rs
+│   │   └── device_dashboard_web.rs
+│   │
+│   ├── platform-esp32/      # original ESP32 adapter layer
+│   │   ├── gpio.rs          # Esp32OutputPin / Esp32InputPin
+│   │   ├── i2c.rs           # Esp32I2c
+│   │   ├── pwm.rs           # Esp32PwmOutput
+│   │   ├── shared_i2c.rs    # SharedI2cBus
+│   │   ├── bme280.rs        # reference-drivers re-export
+│   │   ├── lcd1602.rs       # reference-drivers re-export
+│   │   └── types.rs         # composed type aliases
+│   │
+│   └── platform-avr/        # classic AVR adapter layer
+│       ├── gpio.rs
+│       └── i2c.rs
 │
-├── Cargo.toml            # ワークスペース設定（resolver = "2"）
-├── .gitignore            # Cargo.lockを含む
-└── CLAUDE.md             # このファイル
+├── firmware/
+│   ├── original-esp32-bringup/
+│   ├── original-esp32-climate-display/
+│   ├── m5stickc-bringup/
+│   └── arduino-nano-bringup/
+├── docs/
+├── scripts/
+└── .github/workflows/ci.yml
 ```
 
-### クレートの依存関係
+## 依存関係の考え方
 
+```text
+platform-pc-sim ─┐
+platform-esp32 ──┼─> core-app ─> hal-api
+platform-avr  ───┘
+
+reference-drivers -> hal-api / embedded-hal
+platform-esp32    -> reference-drivers re-export + adapter wrappers
+platform-pc-sim   -> host-side mocks and dashboards
 ```
-platform-pc-sim  ─┐
-                  ├─→ core-app ─→ hal-api
-platform-esp32 ───┘       ↑          ↑
-                           │          │
-                      (App型)    (trait定義)
-```
 
----
+`core-app` は board 固有型に依存させず、`hal-api` trait と error contract のみを見るようにします。
 
-## テスト構成（現状）
-
-| クレート | テストタイプ | テスト数 | PR |
-|---------|------------|---------|-----|
-| hal-api | ドキュメントテスト | 17個 | #21 |
-| core-app | ユニット + doc test | 25個 | #22 他 |
-| platform-pc-sim | ユニット + 統合 + doc test | 17個 | #23 他 |
-| **合計** | | **59個** | |
-
-### テスト実行コマンド
+## よく使うコマンド
 
 ```bash
-# すべてのテスト（最も一般的）
-cargo test --all
+# workspace 全体のテスト
+cargo test --workspace --all-targets
 
-# 特定のクレートのみ
-cargo test -p hal-api
-cargo test -p core-app
-cargo test -p platform-pc-sim
-
-# ドキュメントテストのみ
-cargo test --doc -p hal-api
-
-# 詳細出力（print!デバッグ時）
-cargo test -- --nocapture
-
-# 特定のテスト名で絞り込み
-cargo test test_led_toggles
-```
-
-### テスト配置ルール
-
-**hal-api**: ドキュメントテスト（公開APIの使用例）
-```rust
-/// GPIO出力ピンを制御するtrait
-///
-/// # Examples
-///
-/// ```
-/// use hal_api::gpio::OutputPin;
-/// // 実行可能なサンプルコード
-/// ```
-pub trait OutputPin { ... }
-```
-
-**core-app**: ユニットテスト（ビジネスロジックの検証）
-```rust
-// lib.rsの末尾
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_led_toggles_every_100_ticks() { ... }
-}
-```
-
-**platform-pc-sim**: ユニットテスト（モックHALの動作確認）
-```rust
-// mock_hal.rsの末尾
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_mock_pin_set_high() { ... }
-}
-```
-
----
-
-## Rust固有のコーディング規約
-
-### 1. エラーハンドリング
-
-```rust
-// ✅ Good: Result型と?演算子
-pub fn tick(&mut self) -> Result<(), AppError> {
-    self.pin.set(self.led_state)?;
-    self.i2c.read(0x48, &mut buffer)?;
-    Ok(())
-}
-
-// ❌ Bad: unwrap()の使用（テスト以外）
-pub fn tick(&mut self) {
-    self.pin.set(self.led_state).unwrap();  // 避ける
-}
-```
-
-### 2. エラー型の設計
-
-```rust
-// AppErrorは具体的なHALエラーをラップ
-#[derive(Debug)]
-pub enum AppError {
-    Gpio(GpioError),
-    I2c(I2cError),
-}
-
-// From traitで?演算子が使える
-impl From<GpioError> for AppError {
-    fn from(err: GpioError) -> Self {
-        AppError::Gpio(err)
-    }
-}
-```
-
-### 3. ジェネリックなHAL設計
-
-```rust
-// HAL traitに依存、具体的な実装には依存しない
-pub struct App<PIN, I2C>
-where
-    PIN: OutputPin<Error = GpioError>,
-    I2C: I2cBus<Error = I2cError>,
-{
-    pin: PIN,
-    i2c: I2C,
-    // ...
-}
-```
-
-### 4. テスト用ヘルパー
-
-```rust
-// #[cfg(test)]で本番ビルドから除外
-#[cfg(test)]
-pub fn tick_count(&self) -> u32 {
-    self.tick_count
-}
-```
-
----
-
-## ビルドとリリース
-
-### ローカルビルド
-
-```bash
-# 開発ビルド
-cargo build
-
-# リリースビルド（最適化）
-cargo build --release
-
-# 特定のクレートのみ
-cargo build -p platform-pc-sim
-
-# フォーマットチェック
-cargo fmt -- --check
-
-# Clippy（Linter）
-cargo clippy -- -D warnings
-```
-
-### 実行
-
-```bash
-# PCシミュレータを実行
-cargo run -p platform-pc-sim
-
-# リリースビルドで実行
-cargo run -p platform-pc-sim --release
-```
-
----
-
-## CI/CD（Week 3で実装済み）
-
-### GitHub Actions設定
-
-`.github/workflows/ci.yml` で以下を自動化:
-
-```yaml
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - cargo test --all --verbose
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - cargo build --all --release --verbose
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - cargo fmt --all -- --check
-
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - cargo clippy --all --all-targets -- -D warnings
-```
-
-### CI検証ベストプラクティス
-
-#### ローカル検証（PRを作成する前）
-
-```bash
-# すべてのCIチェックをローカルで実行
-./scripts/ci-local.sh
-
-# または手動で実行
-cargo test --all --verbose
-cargo build --all --release --verbose
+# format / lint
 cargo fmt --all -- --check
 cargo clippy --all --all-targets -- -D warnings
+
+# ローカル CI 相当
+./scripts/ci-local.sh
+
+# no_std / ESP32 関連チェック
+cargo check -p hal-api --lib --target thumbv6m-none-eabi
+cargo check -p core-app --lib --target thumbv6m-none-eabi
+cargo check -p platform-esp32 --lib --target thumbv6m-none-eabi
+cargo check-esp32
+
+# reference path 周辺の絞り込み
+cargo test -p core-app climate_display
+cargo test -p reference-drivers bme280
+cargo test -p reference-drivers lcd1602
+cargo test -p platform-esp32 shared_i2c
+cargo test -p platform-esp32 --test climate_bridge
 ```
 
-#### CI失敗時のデバッグ
+## Simulator / firmware の使い分け
 
 ```bash
-# 最新のワークフロー状態を確認
-gh run list --limit 1
+# ClimateDisplayApp の terminal 16x2 表示
+cargo run -p platform-pc-sim --bin climate-display-sim
 
-# 特定のワークフローの詳細ログを取得
-gh run view <run-id> --log-failed
+# 配線 view 付き terminal dashboard
+cargo run -p platform-pc-sim --bin climate-dashboard-sim
+cargo run -p platform-pc-sim --bin climate-dashboard-sim -- nano
 
-# Clippyエラーの詳細を確認
-gh run view <run-id> --log-failed 2>&1 | grep -A 20 "clippy"
+# browser dashboard
+cargo run -p platform-pc-sim --bin device-dashboard-web
+cargo run -p platform-pc-sim --bin device-dashboard-web -- nano 7878
+
+# original ESP32 bring-up
+cd firmware/original-esp32-bringup
+cargo run --release
+
+# original ESP32 climate display
+cd firmware/original-esp32-climate-display
+cargo check --release
+cargo run --release
 ```
 
-#### よくあるCI失敗パターンと対処法
+## original ESP32 reference path
 
-| エラー | 原因 | 対処法 |
-|--------|------|--------|
-| `bool_assert_comparison` | `assert_eq!(bool, true/false)` | `assert!(bool)` または `assert!(!bool)` に変更 |
-| `manual_is_multiple_of` | `x % n == 0` | `#[allow(clippy::manual_is_multiple_of)]` を追加（unstable機能） |
-| Formatエラー | 末尾の改行、複数の空行 | `cargo fmt --all` で自動修正 |
-| `dead_code` warning | 未使用のフィールド/関数 | `#[allow(dead_code)]` を追加またはコードを削除 |
+`core_app::climate_display::ClimateDisplayApp` は次の 2 経路で共通利用します。
 
-### rustfmt設定
+- PC simulator
+  - `platform-pc-sim::climate_sim::{SequenceEnvSensor, TerminalDisplay16x2}`
+  - `platform-pc-sim::{virtual_i2c::VirtualI2cBus, bme280_mock::MockBme280Device, lcd1602_mock::MockLcd1602Device}`
+- original ESP32
+  - `platform-esp32::{Bme280Sensor, Lcd1602Display, SharedI2cBus}`
+  - firmware: `firmware/original-esp32-climate-display`
 
-`rustfmt.toml` の設定:
+既定の実機想定:
 
-```toml
-edition = "2021"
-max_width = 100
-tab_spaces = 4
-newline_style = "Unix"
-use_field_init_shorthand = true
-use_try_shorthand = true
-```
+- board: original ESP32 / ESP32-WROOM-32 系
+- I2C: `GPIO21` = SDA, `GPIO22` = SCL
+- BME280: `0x77` 優先、必要に応じて `0x76`
+- LCD1602 backpack: `0x27`
 
-**注意**: unstable機能（`imports_granularity`など）はnightly必須のため使用しない
+## 実装ルール
 
----
+- `core-app` に board 固有分岐を入れない
+- board / sensor / display 差分は config struct に閉じ込める
+- `reference-drivers` は board 非依存を維持する
+- `platform-esp32` は adapter / re-export / type alias を中心に薄く保つ
+- host simulator で先に contract を固定してから実機経路に接続する
+- 実機手順や wiring 前提を変えたら README / PLAN / firmware README を同期する
 
-## no_std対応（Week 6予定）
+## テスト方針
 
-### 現在の状況
-- `hal-api`、`core-app`: `std`に依存
-- `platform-pc-sim`: `std`必須（シミュレータ）
+- 新規 trait / driver / adapter には正常系だけでなく error propagation のテストを追加する
+- `ClimateDisplayApp` は sensor error / display error / tick scheduling / frame formatting を回帰テストで固定する
+- BME280 / LCD1602 / SharedI2cBus は I2C error mapping と fallback behavior をテストする
+- `no_std` 対象 crate に `std` 依存を漏らさない。テスト helper は `#[cfg(test)] extern crate std;` に閉じ込める
 
-### 将来の対応方針
+## PR / CI 運用
 
-```rust
-// hal-api/lib.rs、core-app/lib.rs
-#![cfg_attr(not(feature = "std"), no_std)]
-
-#[cfg(feature = "std")]
-extern crate std;
-```
-
-```toml
-# Cargo.toml
-[features]
-default = ["std"]
-std = []
-```
-
----
-
-## ESP32開発（Week 7-8予定）
-
-### 必要なツール
+PR 前に最低限次を実行します。
 
 ```bash
-# espup（ESP32 Rustツールチェーン）
-cargo install espup
-espup install
-
-# espflash（書き込みツール）
-cargo install espflash
+cargo fmt --all -- --check
+cargo clippy --all --all-targets -- -D warnings
+cargo test --workspace --all-targets
 ```
 
-### ESP32向けビルド・書き込み
+reference path / ESP32 周辺を触った場合は、可能なら以下も確認します。
 
 ```bash
-# ビルド
-cargo build -p platform-esp32
-
-# 実機書き込み・モニタ
-cargo espflash flash -p platform-esp32 --monitor
+cargo check-esp32
+./scripts/ci-local.sh
 ```
 
-### ESP32実装の構成
-
-```
-platform-esp32/
-├── Cargo.toml
-├── .cargo/config.toml
-├── rust-toolchain.toml
-└── src/
-    ├── main.rs
-    ├── esp32_gpio.rs  # Esp32OutputPin実装
-    └── esp32_i2c.rs   # Esp32I2c実装
-```
-
----
-
-## トラブルシューティング
-
-### ビルドエラー時
-
-```bash
-# 依存関係を更新
-cargo update
-
-# クリーンビルド
-cargo clean && cargo build
-```
-
-### テスト失敗時
-
-```bash
-# 特定のテストのみ実行（詳細出力）
-cargo test test_name -- --nocapture
-
-# ログレベルを上げる
-RUST_LOG=debug cargo test
-```
-
-### Cargo.lock関連
-
-- このプロジェクトでは`.gitignore`にCargo.lockを含む
-- 理由: ライブラリプロジェクト（hal-api、core-app）がメイン
-- CIでは常に最新の依存関係でテスト
-
----
-
-## Examples作成ガイドライン（Week 4で確立）
-
-### Examplesの配置
-
-Examplesはワークスペースルートの`examples/`ディレクトリに配置:
-
-```
-mcu-hal-sim-rs/
-├── examples/
-│   ├── basic_blink.rs      # 基本的な使用例
-│   ├── i2c_read.rs          # I2C通信の例
-│   └── custom_timing.rs     # 高度な例
-├── Cargo.toml               # [package]セクション必須
-└── crates/
-```
-
-### ワークスペースルートのCargo.toml設定
-
-Examplesを認識させるため、ワークスペースルートに`[package]`セクションを追加:
-
-```toml
-[workspace]
-resolver = "2"
-members = [
-    "crates/hal-api",
-    "crates/core-app",
-    "crates/platform-pc-sim",
-]
-
-[package]
-name = "mcu-hal-sim-rs"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-hal-api = { path = "crates/hal-api" }
-core-app = { path = "crates/core-app" }
-```
-
-### Exampleのテンプレート
-
-```rust
-//! # Example Title
-//!
-//! 簡潔な説明（1-2文）
-//!
-//! ## 実行方法
-//!
-//! ```bash
-//! cargo run --example example_name
-//! ```
-//!
-//! ## 期待される出力
-//!
-//! ```text
-//! 出力例
-//! ```
-
-use core_app::App;
-use std::thread;
-use std::time::Duration;
-
-// モックHALの定義（各exampleで独自に定義）
-mod mock_hal {
-    // MockPin、MockI2cの実装
-}
-
-use mock_hal::{MockI2c, MockPin};
-
-fn main() {
-    println!("=== Example Title ===");
-    // 実装
-}
-```
-
-### Exampleの実行とビルド
-
-```bash
-# 単一のexampleを実行
-cargo run --example basic_blink
-
-# 全examplesをビルド
-cargo build --examples
-
-# 特定のexampleをビルド
-cargo build --example i2c_read
-```
-
-### 注意点
-
-- 各exampleは独立して実行可能にする
-- コメントで初心者にも理解しやすく説明
-- `#[allow(dead_code)]`で未使用警告を抑制（必要に応じて）
-
----
-
-## 開発ロードマップ
-
-| Week | フェーズ | 内容 | 状態 |
-|------|---------|------|------|
-| 1 | Phase 1完成 | Issue #13実装 | ✅ 完了 |
-| 2 | テスト基盤 | 57個のテスト追加 | ✅ 完了 |
-| 3 | CI/CD | GitHub Actions整備 | ✅ 完了 |
-| 4 | ドキュメント | README、examples | 🚧 進行中 |
-| 5 | 統合テスト | カバレッジ80%+ | 📅 予定 |
-| 6 | no_std対応 | ESP32準備 | 📅 予定 |
-| 7-8 | ESP32実装 | 実機動作確認 | 📅 オプション |
-
----
-
-## 参考資料
-
-### Rust関連
-- [Rust Book - Testing](https://doc.rust-lang.org/book/ch11-00-testing.html)
-- [Cargo Book](https://doc.rust-lang.org/cargo/)
-- [embedded-hal traits](https://docs.rs/embedded-hal/latest/embedded_hal/)
-
-### ESP32関連
-- [esp-rs Book](https://esp-rs.github.io/book/)
-- [espflash Documentation](https://github.com/esp-rs/espflash)
-
----
+AI Agent レビューと CI が問題なければ、低リスクなテスト・ドキュメント・小規模修正 PR はマージ可能です。重要PR（実機破壊リスク、secrets/auth/security、破壊的設計変更、大規模アーキテクチャ変更など）はユーザーへエスカレーションします。
 
 ## 重要な原則
 
-このプロジェクトでは **TDD（テスト駆動開発）** が必須です：
+このプロジェクトでは **TDD / 小さなPR / sim-to-real contract の維持** を優先します。
 
-🔴 **Red**: テストを先に書く → 失敗を確認
-🟢 **Green**: 最小限の実装 → テスト成功
-🔵 **Refactor**: コード改善 → テスト維持
+- Red: 期待する contract をテストで固定
+- Green: 最小限の実装で通す
+- Refactor: `core-app` と platform 層の責務分離を維持
 
-詳細は `/home/takeshi_miura/workspace/CLAUDE.md` を参照してください。
+詳細な全体方針は `PLAN.md` と `README.md` も参照してください。

--- a/PLAN.md
+++ b/PLAN.md
@@ -76,8 +76,8 @@
 
 ### B. 本線の品質維持と拡張しやすさの両立
 
-- `ClimateDisplayApp` の回帰テストを増やす
-- BME280 / LCD1602 / shared I2C の異常系を補強する
+- `ClimateDisplayApp` の回帰テストを維持し、sensor / display error と tick scheduling の契約を固定する
+- BME280 / LCD1602 / shared I2C の異常系テストを維持し、I2C error propagation と fallback behavior を固定する
 - 実機確認済みの手順をドキュメントへ維持する
 - app / sensor / display 差分を config struct で表現し、board 固有差分を core へ漏らしにくくする
 

--- a/firmware/original-esp32-climate-display/README.md
+++ b/firmware/original-esp32-climate-display/README.md
@@ -59,16 +59,16 @@ climate refresh tick=10 temp_cc=2481 hum_cp=4315 line1="Temp    24.8C   " line2=
 
 この出力は simulator 側の expected frame と比較しやすいようにしています。
 
-## この branch での確認範囲
+## 確認範囲
 
 - host 側の `cargo test --workspace --all-targets`
 - host 側の `cargo clippy --workspace --all-targets -- -D warnings`
-- この crate の `cargo build --release`
+- この crate の `cargo check --release` または toolchain / linker が揃った環境での `cargo build --release`
 - `scripts/flash-esp32.sh original-esp32-climate-display` による one-command flash
 - macOS: `/dev/cu.*` の自動検出、Linux: `/dev/ttyUSB*` の自動検出
 - Windows WSL2 環境では `espflash.exe` 経由でのポート指定 flash
 - original ESP32 + `BME280` + `LCD1602` で温湿度表示を実機確認
-- 実機シリアルで `climate refresh tick = ...` の継続出力を確認
+- 実機シリアルで `climate refresh tick=...` の継続出力を確認
 
 ## 既知の前提
 


### PR DESCRIPTION
## 概要

CLAUDE.md / PLAN.md / firmware README を現在の実装状態に同期しました。

## 変更点

### CLAUDE.md（全面更新）
- **旧**: Phase 1〜4の Week 計画ベースで、platform-esp32「未実装」と記載。テスト数 59個時点の古い記述。
- **新**: 現状の reference path・フェーズ・構成を正確に記述。
  - reference path: `platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD1602`
  - 完了済みフェーズ（BME280/LCD1602/SharedI2cBus 異常系テスト含む）を反映
  - スコープ方針（ESP32-CAM は別 repo 先行）を明記
  - 実際のファイル構成・コマンド・テスト方針・PR/CI 運用に整理

### PLAN.md（微修正）
- 「異常系を補強する」→「異常系テストを維持し…契約を固定する」（PR #118 / #119 完了済みの実態に合わせる）

### firmware/original-esp32-climate-display/README.md（微修正）
- 「この branch での確認範囲」→「確認範囲」（branch 固有表現を除去）
- `cargo build --release` に toolchain 要件の補足を追加
- シリアルログサンプルとの `tick=` 表記を統一

## テスト
変更はドキュメントのみです。
`cargo test --workspace --all-targets` exit 0 を確認済み。