### PR TITLE
ci: add clippy to no_std and ESP32-C3 cross-check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.NO_STD_TARGET }}
+          components: clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -156,10 +157,25 @@ jobs:
         run: cargo check -p reference-drivers --lib --target $NO_STD_TARGET --no-default-features
 
       - name: Check platform-esp32 for no_std target
-        run: cargo check -p platform-esp32 --lib --target $NO_STD_TARGET
+        run: cargo check -p platform-esp32 --lib --target $NO_STD_TARGET --no-default-features
 
       - name: Check platform-avr for no_std target
-        run: cargo check -p platform-avr --lib --target $NO_STD_TARGET
+        run: cargo check -p platform-avr --lib --target $NO_STD_TARGET --no-default-features
+
+      - name: Clippy hal-api for no_std target
+        run: cargo clippy -p hal-api --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy core-app for no_std target
+        run: cargo clippy -p core-app --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy reference-drivers for no_std target
+        run: cargo clippy -p reference-drivers --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy platform-esp32 for no_std target
+        run: cargo clippy -p platform-esp32 --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy platform-avr for no_std target
+        run: cargo clippy -p platform-avr --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
 
   esp32c3:
     name: ESP32-C3 Cross Check
@@ -172,6 +188,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.ESP32C3_TARGET }}
+          components: clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -201,7 +218,19 @@ jobs:
         run: cargo check -p reference-drivers --lib --target $ESP32C3_TARGET --no-default-features
 
       - name: Check platform-esp32 for ESP32-C3
-        run: cargo check -p platform-esp32 --lib --target $ESP32C3_TARGET
+        run: cargo check -p platform-esp32 --lib --target $ESP32C3_TARGET --no-default-features
+
+      - name: Clippy hal-api for ESP32-C3
+        run: cargo clippy -p hal-api --lib --target $ESP32C3_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy core-app for ESP32-C3
+        run: cargo clippy -p core-app --lib --target $ESP32C3_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy reference-drivers for ESP32-C3
+        run: cargo clippy -p reference-drivers --lib --target $ESP32C3_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy platform-esp32 for ESP32-C3
+        run: cargo clippy -p platform-esp32 --lib --target $ESP32C3_TARGET --no-default-features -- -D warnings
 
   coverage:
     name: Coverage


### PR DESCRIPTION
## 概要

CI の `no_std Check` / `ESP32-C3 Cross Check` ジョブに `cargo clippy` ステップを追加しました。

## 変更内容

### no_std Check ジョブ
- `components: clippy` を toolchain インストールに追加
- `platform-esp32` / `platform-avr` の check に `--no-default-features` を明示（既存は一部欠けていた）
- 5 crate すべてに clippy ステップを追加（`-D warnings`）

### ESP32-C3 Cross Check ジョブ
- `components: clippy` を toolchain インストールに追加
- `platform-esp32` の check に `--no-default-features` を明示
- 4 crate すべてに clippy ステップを追加（`-D warnings`）

## 目的

no_std / クロスビルド環境での警告ゼロを CI で継続保証し、std 依存の漏れや dead_code の混入を早期検出できるようにします。

## ローカル検証

```bash
# thumbv6m-none-eabi clippy: 全 crate 0 warnings
cargo clippy -p {hal-api,core-app,reference-drivers,platform-esp32,platform-avr} \
  --lib --target thumbv6m-none-eabi --no-default-features -- -D warnings
# riscv32imc-unknown-none-elf clippy: 全 crate 0 warnings
cargo clippy -p {hal-api,core-app,reference-drivers,platform-esp32} \
  --lib --target riscv32imc-unknown-none-elf --no-default-features -- -D warnings
# workspace テスト / clippy / fmt: exit 0
```