### PR TITLE
test(reference-drivers): add error-path tests for bh1750, ssd1306, mpu6050

### DIFF
--- a/crates/reference-drivers/bh1750.rs
+++ b/crates/reference-drivers/bh1750.rs
@@ -62,6 +62,7 @@ mod tests {
     use hal_api::error::I2cError;
     use hal_api::i2c::I2cBus;
 
+    /// 正常系用 stub: write は成功、read は固定 raw 値を返す
     struct StubI2c {
         raw_high: u8,
         raw_low: u8,
@@ -96,6 +97,57 @@ mod tests {
         }
     }
 
+    /// 異常系用 stub: write または read で即エラーを返す
+    struct FailingI2c {
+        fail_write: bool,
+        fail_read: bool,
+        error: I2cError,
+    }
+
+    impl FailingI2c {
+        fn fail_on_write(error: I2cError) -> Self {
+            Self {
+                fail_write: true,
+                fail_read: false,
+                error,
+            }
+        }
+
+        fn fail_on_read(error: I2cError) -> Self {
+            Self {
+                fail_write: false,
+                fail_read: true,
+                error,
+            }
+        }
+    }
+
+    impl I2cBus for FailingI2c {
+        type Error = I2cError;
+        fn write(&mut self, _addr: u8, _data: &[u8]) -> Result<(), I2cError> {
+            if self.fail_write {
+                Err(self.error.clone())
+            } else {
+                Ok(())
+            }
+        }
+        fn read(&mut self, _addr: u8, _buf: &mut [u8]) -> Result<(), I2cError> {
+            if self.fail_read {
+                Err(self.error.clone())
+            } else {
+                Ok(())
+            }
+        }
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _write: &[u8],
+            _buf: &mut [u8],
+        ) -> Result<(), I2cError> {
+            Err(self.error.clone())
+        }
+    }
+
     #[test]
     fn bh1750_converts_raw_to_lux_x100() {
         // raw=1200 → lux = 1200/1.2 = 1000 → lux×100 = 100000
@@ -111,5 +163,34 @@ mod tests {
         let mut sensor = Bh1750Sensor::new(i2c, BH1750_ADDRESS_LOW).unwrap();
         let reading = sensor.read_lux().unwrap();
         assert_eq!(reading.lux_x100, 0);
+    }
+
+    #[test]
+    fn bh1750_new_maps_write_error_to_bus_error() {
+        // power_on 内の write が失敗 → SensorError::BusError として伝播
+        let i2c = FailingI2c::fail_on_write(I2cError::BusError);
+        match Bh1750Sensor::new(i2c, BH1750_ADDRESS_LOW) {
+            Err(e) => assert_eq!(e, SensorError::BusError),
+            Ok(_) => panic!("expected Err, got Ok"),
+        }
+    }
+
+    #[test]
+    fn bh1750_read_lux_maps_read_error_to_bus_error() {
+        // 初期化は成功させ、read_lux 時の read が失敗 → SensorError::BusError
+        let i2c = FailingI2c::fail_on_read(I2cError::Timeout);
+        let result = Bh1750Sensor::new(i2c, BH1750_ADDRESS_LOW);
+        assert!(result.is_ok(), "new should succeed when write passes");
+        let mut sensor = result.unwrap();
+        assert_eq!(sensor.read_lux(), Err(SensorError::BusError));
+    }
+
+    #[test]
+    fn bh1750_new_uses_high_address() {
+        let i2c = StubI2c::new(600);
+        let mut sensor = Bh1750Sensor::new(i2c, BH1750_ADDRESS_HIGH).unwrap();
+        // アドレスが高い方でも正常に計測できること
+        let reading = sensor.read_lux().unwrap();
+        assert_eq!(reading.lux_integer(), 500);
     }
 }

--- a/crates/reference-drivers/mpu6050.rs
+++ b/crates/reference-drivers/mpu6050.rs
@@ -350,4 +350,42 @@ mod tests {
 
         assert_eq!(reading.accel_mg[0], 2000);
     }
+
+    #[test]
+    fn mpu6050_maps_write_read_bus_error_during_init() {
+        // WHO_AM_I の read_registers で write_read が失敗
+        // registers 空 → write_read が InvalidAddress を返す
+        // map_sensor_error: InvalidAddress → SensorError::NotInitialized
+        let bus = RecordingI2c::default();
+        let mut sensor = Mpu6050Sensor::new(bus);
+        let err = sensor.read_imu().expect_err("should fail");
+        assert_eq!(err, SensorError::NotInitialized);
+    }
+
+    #[test]
+    fn mpu6050_maps_data_read_failure_to_bus_error() {
+        // init は成功するが ACCEL_XOUT_H が未設定 → データ読み取りで InvalidAddress
+        // map_sensor_error: InvalidAddress → SensorError::NotInitialized
+        let bus = RecordingI2c::with_register(REG_WHO_AM_I, &[WHO_AM_I_MPU6050]);
+        // ACCEL_XOUT_H は未設定
+        let mut sensor = Mpu6050Sensor::new(bus);
+        let err = sensor.read_imu().expect_err("should fail");
+        assert_eq!(err, SensorError::NotInitialized);
+    }
+
+    #[test]
+    fn mpu6050_does_not_reinitialize_after_success() {
+        // 一度 init が成功したら is_initialized が true になり、2 回目の read_imu では init をスキップ
+        let bus = RecordingI2c::with_register(REG_WHO_AM_I, &[WHO_AM_I_MPU6050]);
+        bus.set_register(REG_ACCEL_XOUT_H, &sample_frame());
+        let mut sensor = Mpu6050Sensor::new(bus.clone());
+
+        let _ = sensor.read_imu().unwrap();
+        assert!(sensor.is_initialized());
+
+        let writes_after_first = bus.writes().len();
+        let _ = sensor.read_imu().unwrap();
+        // 2 回目は init の write (4回) が走らない
+        assert_eq!(bus.writes().len(), writes_after_first);
+    }
 }

--- a/crates/reference-drivers/ssd1306.rs
+++ b/crates/reference-drivers/ssd1306.rs
@@ -315,6 +315,42 @@ mod tests {
     }
 
     #[test]
+    fn ssd1306_init_failure_returns_display_error() {
+        // write が即失敗 → new が DisplayError::BusError を返す
+        let i2c = FailI2c;
+        match Ssd1306Display::new(i2c, SSD1306_ADDRESS_DEFAULT) {
+            Err(e) => assert_eq!(e, DisplayError::BusError),
+            Ok(_) => panic!("expected Err, got Ok"),
+        }
+    }
+
+    #[test]
+    fn ssd1306_alt_address_is_accepted() {
+        let i2c = StubI2c::default();
+        assert!(Ssd1306Display::new(i2c, SSD1306_ADDRESS_ALT).is_ok());
+    }
+
+    // 常に BusError を返す最小 stub
+    struct FailI2c;
+    impl I2cBus for FailI2c {
+        type Error = I2cError;
+        fn write(&mut self, _addr: u8, _data: &[u8]) -> Result<(), I2cError> {
+            Err(I2cError::BusError)
+        }
+        fn read(&mut self, _addr: u8, _buf: &mut [u8]) -> Result<(), I2cError> {
+            Err(I2cError::BusError)
+        }
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _write: &[u8],
+            _buf: &mut [u8],
+        ) -> Result<(), I2cError> {
+            Err(I2cError::BusError)
+        }
+    }
+
+    #[test]
     fn ssd1306_font_digit_is_nonzero() {
         let table = include_font();
         // Digits '0'-'9' are at index 16-25


### PR DESCRIPTION
## 概要

`reference-drivers` の 3 ドライバに error-path テストを追加しました。
テスト数: 67 → **75** (+8)

## 変更内容

### bh1750.rs (+3 テスト)
- `bh1750_new_maps_write_error_to_bus_error`: `power_on` 内の write 失敗 → `SensorError::BusError`
- `bh1750_read_lux_maps_read_error_to_bus_error`: `read_lux` の read 失敗 → `SensorError::BusError`
- `bh1750_new_uses_high_address`: `BH1750_ADDRESS_HIGH` でも正常計測できること

### ssd1306.rs (+2 テスト)
- `ssd1306_init_failure_returns_display_error`: `new` 時の write 失敗 → `DisplayError::BusError`
- `ssd1306_alt_address_is_accepted`: `SSD1306_ADDRESS_ALT` (0x3D) での初期化成功

### mpu6050.rs (+3 テスト)
- `mpu6050_maps_write_read_bus_error_during_init`: WHO_AM_I read 失敗 → `SensorError::NotInitialized`
- `mpu6050_maps_data_read_failure_to_bus_error`: ACCEL_XOUT_H 未設定時のデータ読み取り失敗 → `SensorError::NotInitialized`
- `mpu6050_does_not_reinitialize_after_success`: 初期化成功後に 2 回目の `read_imu` では init をスキップすること

## ローカル検証

```
cargo fmt --all -- --check ✅
cargo clippy --all --all-targets -- -D warnings ✅
cargo test --workspace --all-targets ✅ (全テスト passed)
```