### PR TITLE
feat(platform-rp2040): add Raspberry Pi Pico adapter crate and bringup firmware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Check platform-avr for no_std target
         run: cargo check -p platform-avr --lib --target $NO_STD_TARGET --no-default-features
 
+      - name: Check platform-rp2040 for no_std target
+        run: cargo check -p platform-rp2040 --lib --target $NO_STD_TARGET --no-default-features
+
       - name: Clippy hal-api for no_std target
         run: cargo clippy -p hal-api --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
 
@@ -176,6 +179,9 @@ jobs:
 
       - name: Clippy platform-avr for no_std target
         run: cargo clippy -p platform-avr --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
+
+      - name: Clippy platform-rp2040 for no_std target
+        run: cargo clippy -p platform-rp2040 --lib --target $NO_STD_TARGET --no-default-features -- -D warnings
 
   esp32c3:
     name: ESP32-C3 Cross Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD1602
 ```
 
-この repo では `hal-api` / `core-app` / `reference-drivers` / `platform-*` の責務分離と、sim-to-real 契約の固定を優先します。`M5StickC` は補助診断ボード、`Arduino Nano` / `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` は将来候補または別 repo 先行の拡張候補として扱います。
+この repo では `hal-api` / `core-app` / `reference-drivers` / `platform-*` の責務分離と、sim-to-real 契約の固定を優先します。`M5StickC` は補助診断ボード、`Teensy` / `ESP32-CAM` は将来候補または別 repo 先行の拡張候補として扱います。
 
 ## 現在のフェーズ
 
@@ -22,7 +22,8 @@ platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD16
 - ✅ `platform-esp32` の adapter 層と original ESP32 bring-up firmware
 - ✅ `ClimateDisplayApp` の PC simulator と original ESP32 climate display reference path
 - ✅ BME280 / LCD1602 / SharedI2cBus の基本・異常系テスト
-- 🚧 Phase 4: no_std 対応と original ESP32 実機確認手順の維持・拡張
+- ✅ `platform-rp2040` の adapter 層と Raspberry Pi Pico bring-up firmware
+- 🚧 Phase 4: no_std 対応と original ESP32 / Raspberry Pi Pico 実機確認手順の維持・拡張
 
 ## スコープ方針
 
@@ -31,7 +32,7 @@ platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD16
 - `hal-api` の汎用抽象
 - `core-app` の再利用可能なアプリロジック
 - `reference-drivers` の board 非依存 driver
-- `platform-pc-sim` / `platform-avr` / `platform-esp32` の sim-to-real 経路
+- `platform-pc-sim` / `platform-avr` / `platform-esp32` / `platform-rp2040` の sim-to-real 経路
 - original ESP32 + BME280 + LCD1602 の本線シナリオ
 - 共通化価値がある sensor / display / actuator 契約とテスト
 
@@ -94,15 +95,20 @@ mcu-hal-sim-rs/
 │   │   ├── lcd1602.rs       # reference-drivers re-export
 │   │   └── types.rs         # composed type aliases
 │   │
-│   └── platform-avr/        # classic AVR adapter layer
-│       ├── gpio.rs
-│       └── i2c.rs
+│   ├── platform-avr/        # classic AVR adapter layer
+│   │   ├── gpio.rs
+│   │   └── i2c.rs
+│   │
+│   └── platform-rp2040/     # Raspberry Pi Pico (RP2040) adapter layer
+│       ├── gpio.rs          # Rp2040OutputPin / Rp2040InputPin
+│       └── i2c.rs           # Rp2040I2c
 │
 ├── firmware/
 │   ├── original-esp32-bringup/
 │   ├── original-esp32-climate-display/
 │   ├── m5stickc-bringup/
-│   └── arduino-nano-bringup/
+│   ├── arduino-nano-bringup/
+│   └── raspi-pico-bringup/
 ├── docs/
 ├── scripts/
 └── .github/workflows/ci.yml
@@ -111,9 +117,10 @@ mcu-hal-sim-rs/
 ## 依存関係の考え方
 
 ```text
-platform-pc-sim ─┐
-platform-esp32 ──┼─> core-app ─> hal-api
-platform-avr  ───┘
+platform-pc-sim  ─┐
+platform-esp32  ──┼─> core-app ─> hal-api
+platform-avr    ──┤
+platform-rp2040 ──┘
 
 reference-drivers -> hal-api / embedded-hal
 platform-esp32    -> reference-drivers re-export + adapter wrappers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/platform-pc-sim",
     "crates/platform-avr",
     "crates/platform-esp32",
+    "crates/platform-rp2040",
 ]
 
 [package]

--- a/PLAN.md
+++ b/PLAN.md
@@ -3,7 +3,7 @@
 ## 概要
 
 `mcu-hal-sim-rs` は、マイコン向け Rust アプリを **PC simulator で検証し、そのまま実機へ持っていくための基盤 repo** です。
-現時点の reference path は original ESP32 ですが、将来的な `Arduino Nano` / `Raspberry Pi Pico` / `Teensy` / `ESP32-CAM` 展開を見据え、`hal-api` / `core-app` / `platform-*` の責務分離と sim-to-real 契約の固定を主目的にします。
+現時点の reference path は original ESP32 ですが、`Arduino Nano` / `Raspberry Pi Pico` の adapter 層を追加し、`hal-api` / `core-app` / `platform-*` の責務分離と sim-to-real 契約の固定を主目的にします。`Teensy` / `ESP32-CAM` は将来候補として別 repo 先行で進めます。
 
 ## 現状（2026-03 時点）
 
@@ -23,6 +23,8 @@
   - M5StickC を使った USB / button / onboard I2C の診断
 - `firmware/arduino-nano-bringup`
   - classic Arduino Nano (`ATmega328P`) の LED / serial / I2C scan の切り分け
+- `firmware/raspi-pico-bringup`
+  - Raspberry Pi Pico (RP2040) の LED / UART / I2C scan + `core-app` 統合確認
 
 ## この repo のスコープ
 

--- a/crates/platform-rp2040/Cargo.toml
+++ b/crates/platform-rp2040/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "platform-rp2040"
+version = "0.1.0"
+edition = "2021"
+description = "RP2040 (Raspberry Pi Pico) adapters for the sim-to-real path in mcu-hal-sim-rs"
+license = "MIT"
+repository = "https://github.com/1222-takeshi/mcu-hal-sim-rs"
+documentation = "https://docs.rs/platform-rp2040"
+readme = "README.md"
+keywords = ["embedded", "rp2040", "raspberry-pi-pico", "hal", "no-std"]
+categories = ["embedded", "no-std", "hardware-support"]
+rust-version = "1.66"
+publish = false
+
+[dependencies]
+embedded-hal = "1.0"
+hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[dev-dependencies]
+core-app = { version = "0.1.0", path = "../core-app", default-features = false }

--- a/crates/platform-rp2040/README.md
+++ b/crates/platform-rp2040/README.md
@@ -1,0 +1,45 @@
+# platform-rp2040
+
+Raspberry Pi Pico (RP2040) 向けの `hal-api` adapter 層です。
+
+`embedded-hal` v1.0 互換の GPIO / I2C 実装を `hal-api` trait に橋渡しし、
+`core-app` を Pico 上で動かすための薄い接続層を提供します。
+
+## 提供する型
+
+| 型 | 説明 |
+|---|---|
+| `gpio::Rp2040OutputPin<P>` | 出力ピンラッパー |
+| `gpio::Rp2040InputPin<P>` | 入力ピンラッパー |
+| `i2c::Rp2040I2c<I>` | I2C バスラッパー |
+
+## 使い方
+
+```rust
+use rp_pico::hal;
+use platform_rp2040::{gpio::Rp2040OutputPin, i2c::Rp2040I2c};
+use core_app::App;
+
+// rp2040-hal の型を hal-api adapter でラップ
+let pin = Rp2040OutputPin::new(led_pin);
+let i2c = Rp2040I2c::new(i2c_bus);
+let mut app = App::new(pin, i2c);
+
+loop {
+    app.tick().unwrap();
+}
+```
+
+## ピン配置（Raspberry Pi Pico）
+
+| 機能 | GPIO |
+|---|---|
+| LED (onboard) | GPIO25 |
+| I2C0 SDA | GPIO4 |
+| I2C0 SCL | GPIO5 |
+| UART0 TX | GPIO0 |
+| UART0 RX | GPIO1 |
+
+## 関連クレート
+
+- `firmware/raspi-pico-bringup` — LED / UART / I2C scan + core-app 統合 firmware

--- a/crates/platform-rp2040/gpio.rs
+++ b/crates/platform-rp2040/gpio.rs
@@ -1,0 +1,231 @@
+//! RP2040 GPIO アダプタ
+
+use core::cell::{Ref, RefCell, RefMut};
+
+use embedded_hal::digital::{
+    Error as EmbeddedDigitalError, ErrorKind as EmbeddedDigitalErrorKind,
+    InputPin as EmbeddedInputPin, OutputPin as EmbeddedOutputPin,
+};
+use hal_api::error::GpioError;
+use hal_api::gpio::{InputPin, OutputPin};
+
+fn map_gpio_error(error: impl EmbeddedDigitalError) -> GpioError {
+    match error.kind() {
+        EmbeddedDigitalErrorKind::Other => GpioError::HardwareError,
+        _ => GpioError::HardwareError,
+    }
+}
+
+/// RP2040 向けの出力ピンラッパー。
+pub struct Rp2040OutputPin<P> {
+    inner: P,
+}
+
+impl<P> Rp2040OutputPin<P> {
+    pub fn new(inner: P) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &P {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut P {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> P {
+        self.inner
+    }
+}
+
+impl<P> OutputPin for Rp2040OutputPin<P>
+where
+    P: EmbeddedOutputPin,
+{
+    type Error = GpioError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.inner.set_high().map_err(map_gpio_error)
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.inner.set_low().map_err(map_gpio_error)
+    }
+}
+
+/// RP2040 向けの入力ピンラッパー。
+pub struct Rp2040InputPin<P> {
+    inner: RefCell<P>,
+}
+
+impl<P> Rp2040InputPin<P> {
+    pub fn new(inner: P) -> Self {
+        Self {
+            inner: RefCell::new(inner),
+        }
+    }
+
+    pub fn borrow_inner(&self) -> Ref<'_, P> {
+        self.inner.borrow()
+    }
+
+    pub fn borrow_inner_mut(&self) -> RefMut<'_, P> {
+        self.inner.borrow_mut()
+    }
+
+    pub fn into_inner(self) -> P {
+        self.inner.into_inner()
+    }
+}
+
+impl<P> InputPin for Rp2040InputPin<P>
+where
+    P: EmbeddedInputPin,
+{
+    type Error = GpioError;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        self.inner.borrow_mut().is_high().map_err(map_gpio_error)
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        self.inner.borrow_mut().is_low().map_err(map_gpio_error)
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use core::convert::Infallible;
+
+    use super::*;
+    use embedded_hal::digital::ErrorKind as EmbeddedDigitalErrorKind;
+
+    struct DummyOutputPin {
+        level: bool,
+    }
+
+    impl embedded_hal::digital::ErrorType for DummyOutputPin {
+        type Error = Infallible;
+    }
+
+    impl EmbeddedOutputPin for DummyOutputPin {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            self.level = true;
+            Ok(())
+        }
+
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            self.level = false;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct DummyDigitalError;
+
+    impl embedded_hal::digital::Error for DummyDigitalError {
+        fn kind(&self) -> EmbeddedDigitalErrorKind {
+            EmbeddedDigitalErrorKind::Other
+        }
+    }
+
+    struct FailingOutputPin;
+
+    impl embedded_hal::digital::ErrorType for FailingOutputPin {
+        type Error = DummyDigitalError;
+    }
+
+    impl EmbeddedOutputPin for FailingOutputPin {
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            Err(DummyDigitalError)
+        }
+
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            Err(DummyDigitalError)
+        }
+    }
+
+    struct DummyInputPin {
+        level: bool,
+        high_reads: usize,
+        low_reads: usize,
+    }
+
+    impl embedded_hal::digital::ErrorType for DummyInputPin {
+        type Error = Infallible;
+    }
+
+    impl EmbeddedInputPin for DummyInputPin {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
+            self.high_reads += 1;
+            Ok(self.level)
+        }
+
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
+            self.low_reads += 1;
+            Ok(!self.level)
+        }
+    }
+
+    struct FailingInputPin;
+
+    impl embedded_hal::digital::ErrorType for FailingInputPin {
+        type Error = DummyDigitalError;
+    }
+
+    impl EmbeddedInputPin for FailingInputPin {
+        fn is_high(&mut self) -> Result<bool, Self::Error> {
+            Err(DummyDigitalError)
+        }
+
+        fn is_low(&mut self) -> Result<bool, Self::Error> {
+            Err(DummyDigitalError)
+        }
+    }
+
+    #[test]
+    fn rp2040_output_pin_delegates_to_inner_pin() {
+        let inner = DummyOutputPin { level: false };
+        let mut pin = Rp2040OutputPin::new(inner);
+
+        pin.set_high().unwrap();
+        assert!(pin.inner().level);
+
+        pin.set_low().unwrap();
+        assert!(!pin.inner().level);
+    }
+
+    #[test]
+    fn rp2040_output_pin_maps_embedded_hal_errors() {
+        let mut pin = Rp2040OutputPin::new(FailingOutputPin);
+
+        assert_eq!(pin.set_high(), Err(GpioError::HardwareError));
+        assert_eq!(pin.set_low(), Err(GpioError::HardwareError));
+    }
+
+    #[test]
+    fn rp2040_input_pin_delegates_to_inner_pin() {
+        let pin = Rp2040InputPin::new(DummyInputPin {
+            level: true,
+            high_reads: 0,
+            low_reads: 0,
+        });
+
+        assert!(pin.is_high().unwrap());
+        assert!(!pin.is_low().unwrap());
+        assert_eq!(pin.borrow_inner().high_reads, 1);
+        assert_eq!(pin.borrow_inner().low_reads, 1);
+    }
+
+    #[test]
+    fn rp2040_input_pin_maps_embedded_hal_errors() {
+        let pin = Rp2040InputPin::new(FailingInputPin);
+
+        assert_eq!(pin.is_high(), Err(GpioError::HardwareError));
+        assert_eq!(pin.is_low(), Err(GpioError::HardwareError));
+    }
+}

--- a/crates/platform-rp2040/i2c.rs
+++ b/crates/platform-rp2040/i2c.rs
@@ -1,0 +1,203 @@
+//! RP2040 I2C アダプタ
+
+use embedded_hal::i2c::{
+    Error as EmbeddedI2cError, ErrorKind as EmbeddedI2cErrorKind, I2c as EmbeddedI2c,
+    NoAcknowledgeSource, SevenBitAddress,
+};
+use hal_api::error::I2cError;
+use hal_api::i2c::I2cBus;
+
+fn map_i2c_error(error: impl EmbeddedI2cError) -> I2cError {
+    match error.kind() {
+        EmbeddedI2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Address) => {
+            I2cError::InvalidAddress
+        }
+        EmbeddedI2cErrorKind::Bus
+        | EmbeddedI2cErrorKind::ArbitrationLoss
+        | EmbeddedI2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Data)
+        | EmbeddedI2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown)
+        | EmbeddedI2cErrorKind::Overrun
+        | EmbeddedI2cErrorKind::Other => I2cError::BusError,
+        _ => I2cError::BusError,
+    }
+}
+
+/// RP2040 向けの I2C バスラッパー。
+pub struct Rp2040I2c<I> {
+    inner: I,
+}
+
+impl<I> Rp2040I2c<I> {
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(&self) -> &I {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut I {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+}
+
+impl<I> I2cBus for Rp2040I2c<I>
+where
+    I: EmbeddedI2c<SevenBitAddress>,
+{
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.inner.write(addr, bytes).map_err(map_i2c_error)
+    }
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.read(addr, buffer).map_err(map_i2c_error)
+    }
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner
+            .write_read(addr, bytes, buffer)
+            .map_err(map_i2c_error)
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use core::convert::Infallible;
+
+    use super::*;
+    use embedded_hal::i2c::ErrorKind as EmbeddedI2cErrorKind;
+
+    struct DummyI2c {
+        writes: usize,
+        reads: usize,
+        last_addr: Option<u8>,
+    }
+
+    impl embedded_hal::i2c::ErrorType for DummyI2c {
+        type Error = Infallible;
+    }
+
+    impl EmbeddedI2c<SevenBitAddress> for DummyI2c {
+        fn write(&mut self, addr: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
+            self.writes += 1;
+            self.last_addr = Some(addr);
+            Ok(())
+        }
+
+        fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+            self.reads += 1;
+            self.last_addr = Some(addr);
+            buffer.fill(0xAB);
+            Ok(())
+        }
+
+        fn write_read(
+            &mut self,
+            addr: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            self.write(addr, bytes)?;
+            self.read(addr, buffer)
+        }
+
+        fn transaction(
+            &mut self,
+            addr: u8,
+            operations: &mut [embedded_hal::i2c::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            self.last_addr = Some(addr);
+
+            for operation in operations {
+                match operation {
+                    embedded_hal::i2c::Operation::Read(buffer) => {
+                        self.reads += 1;
+                        buffer.fill(0xAB);
+                    }
+                    embedded_hal::i2c::Operation::Write(bytes) => {
+                        self.writes += 1;
+                        let _ = bytes;
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct DummyI2cDriverError(EmbeddedI2cErrorKind);
+
+    impl embedded_hal::i2c::Error for DummyI2cDriverError {
+        fn kind(&self) -> EmbeddedI2cErrorKind {
+            self.0
+        }
+    }
+
+    struct FailingI2c {
+        error: DummyI2cDriverError,
+    }
+
+    impl embedded_hal::i2c::ErrorType for FailingI2c {
+        type Error = DummyI2cDriverError;
+    }
+
+    impl EmbeddedI2c<SevenBitAddress> for FailingI2c {
+        fn transaction(
+            &mut self,
+            _addr: u8,
+            _operations: &mut [embedded_hal::i2c::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            Err(self.error)
+        }
+    }
+
+    #[test]
+    fn rp2040_i2c_delegates_write_and_read() {
+        let inner = DummyI2c {
+            writes: 0,
+            reads: 0,
+            last_addr: None,
+        };
+        let mut i2c = Rp2040I2c::new(inner);
+        let mut buffer = [0u8; 4];
+
+        i2c.write(0x48, &[0x01]).unwrap();
+        i2c.read(0x48, &mut buffer).unwrap();
+
+        assert_eq!(i2c.inner().writes, 1);
+        assert_eq!(i2c.inner().reads, 1);
+        assert_eq!(i2c.inner().last_addr, Some(0x48));
+        assert_eq!(buffer, [0xAB; 4]);
+    }
+
+    #[test]
+    fn rp2040_i2c_maps_address_errors() {
+        let mut i2c = Rp2040I2c::new(FailingI2c {
+            error: DummyI2cDriverError(EmbeddedI2cErrorKind::NoAcknowledge(
+                NoAcknowledgeSource::Address,
+            )),
+        });
+
+        assert_eq!(i2c.write(0x48, &[0x01]), Err(I2cError::InvalidAddress));
+    }
+
+    #[test]
+    fn rp2040_i2c_maps_bus_errors() {
+        let mut i2c = Rp2040I2c::new(FailingI2c {
+            error: DummyI2cDriverError(EmbeddedI2cErrorKind::Bus),
+        });
+        let mut buffer = [0u8; 2];
+
+        assert_eq!(i2c.read(0x48, &mut buffer), Err(I2cError::BusError));
+    }
+}

--- a/crates/platform-rp2040/lib.rs
+++ b/crates/platform-rp2040/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+//! # Platform RP2040
+//!
+//! Raspberry Pi Pico (RP2040) 向けのプラットフォーム実装の足場です。
+//!
+//! `embedded-hal` v1.0 互換の GPIO / I2C 実装を `hal-api` に橋渡しする
+//! 薄い adapter を提供します。
+//!
+//! これにより、Raspberry Pi Pico を追加するときも、
+//! `core-app` 側を変えずに platform 層だけで吸収できます。
+
+pub mod gpio;
+pub mod i2c;

--- a/crates/platform-rp2040/tests/app_bridge.rs
+++ b/crates/platform-rp2040/tests/app_bridge.rs
@@ -1,0 +1,97 @@
+use core::convert::Infallible;
+
+#[cfg(test)]
+extern crate std;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use core_app::App;
+use embedded_hal::digital::{ErrorType as DigitalErrorType, OutputPin as EmbeddedOutputPin};
+use embedded_hal::i2c::{ErrorType as I2cErrorType, I2c as EmbeddedI2c, SevenBitAddress};
+use platform_rp2040::gpio::Rp2040OutputPin;
+use platform_rp2040::i2c::Rp2040I2c;
+
+#[derive(Clone)]
+struct DummyOutputPin {
+    history: Rc<RefCell<Vec<bool>>>,
+}
+
+impl DummyOutputPin {
+    fn new() -> Self {
+        Self {
+            history: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+}
+
+impl DigitalErrorType for DummyOutputPin {
+    type Error = Infallible;
+}
+
+impl EmbeddedOutputPin for DummyOutputPin {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.history.borrow_mut().push(true);
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.history.borrow_mut().push(false);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct DummyI2c {
+    reads: Rc<RefCell<Vec<(u8, usize)>>>,
+}
+
+impl DummyI2c {
+    fn new() -> Self {
+        Self {
+            reads: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+}
+
+impl I2cErrorType for DummyI2c {
+    type Error = Infallible;
+}
+
+impl EmbeddedI2c<SevenBitAddress> for DummyI2c {
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for operation in operations {
+            if let embedded_hal::i2c::Operation::Read(buffer) = operation {
+                self.reads.borrow_mut().push((address, buffer.len()));
+                buffer.fill(0xAB);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[test]
+fn core_app_runs_with_rp2040_adapters() {
+    let raw_pin = DummyOutputPin::new();
+    let raw_i2c = DummyI2c::new();
+    let pin_history = raw_pin.history.clone();
+    let i2c_reads = raw_i2c.reads.clone();
+
+    let pin = Rp2040OutputPin::new(raw_pin);
+    let i2c = Rp2040I2c::new(raw_i2c);
+    let mut app = App::new(pin, i2c);
+
+    for _ in 0..500 {
+        app.tick().unwrap();
+    }
+
+    assert_eq!(
+        pin_history.borrow().as_slice(),
+        &[true, false, true, false, true]
+    );
+    assert_eq!(i2c_reads.borrow().as_slice(), &[(0x48, 4)]);
+}

--- a/firmware/raspi-pico-bringup/.cargo/config.toml
+++ b/firmware/raspi-pico-bringup/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = "elf2uf2-rs -d"
+rustflags = [
+    "-C", "link-arg=--nmagic",
+    "-C", "link-arg=-Tlink.x",
+]

--- a/firmware/raspi-pico-bringup/Cargo.toml
+++ b/firmware/raspi-pico-bringup/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "raspi-pico-bringup"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[[bin]]
+name = "raspi-pico-bringup"
+path = "src/main.rs"
+test = false
+bench = false
+
+[dependencies]
+rp-pico = "0.9"
+embedded-hal = "1.0"
+panic-halt = "1.0"
+fugit = "0.3"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7"
+platform-rp2040 = { path = "../../crates/platform-rp2040" }
+core-app = { path = "../../crates/core-app", default-features = false }
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = "s"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+debug = true
+lto = true
+opt-level = "s"

--- a/firmware/raspi-pico-bringup/README.md
+++ b/firmware/raspi-pico-bringup/README.md
@@ -1,0 +1,61 @@
+# raspi-pico-bringup
+
+Raspberry Pi Pico 向けの bring-up firmware です。
+
+`platform-rp2040` adapter を経由して `core-app` を動かし、
+sim-to-real 経路の最初の接続確認を行います。
+
+## 確認内容
+
+1. LED 点滅（GPIO25 オンボード LED）
+2. UART 出力（115200 baud, GPIO0=TX / GPIO1=RX）
+3. I2C スキャン（I2C0, GPIO4=SDA / GPIO5=SCL）
+4. `core-app::App` の tick ループ実行
+
+## ピン配置
+
+| 機能 | GPIO | 備考 |
+|---|---|---|
+| LED | GPIO25 | Pico オンボード LED |
+| UART TX | GPIO0 | シリアルモニタに接続 |
+| UART RX | GPIO1 | |
+| I2C SDA | GPIO4 | I2C0 |
+| I2C SCL | GPIO5 | I2C0 |
+
+## 書き込み方法
+
+### UF2 経由（推奨）
+
+```bash
+cd firmware/raspi-pico-bringup
+
+# Pico を BOOTSEL ボタンを押しながら接続 → USB マスストレージとして認識
+cargo run --release
+# elf2uf2-rs が自動的に UF2 に変換して書き込みます
+```
+
+### 前提ツール
+
+```bash
+# elf2uf2-rs インストール
+cargo install elf2uf2-rs
+
+# thumbv6m-none-eabi ターゲット追加（rust-toolchain.toml で自動管理）
+rustup target add thumbv6m-none-eabi
+```
+
+## シリアル出力例
+
+```
+raspi-pico bring-up + hal-api demo
+LED=GPIO25 SDA=GPIO4 SCL=GPIO5 UART0=GPIO0/1
+Use this firmware to confirm blink/UART/I2C before adding sensors.
+I2C scan:
+  found device at 0x27
+  found device at 0x77
+I2C scan done.
+Starting core-app via hal-api adapters...
+heartbeat
+heartbeat
+...
+```

--- a/firmware/raspi-pico-bringup/rust-toolchain.toml
+++ b/firmware/raspi-pico-bringup/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["rust-src"]
+targets = ["thumbv6m-none-eabi"]
+profile = "minimal"

--- a/firmware/raspi-pico-bringup/src/main.rs
+++ b/firmware/raspi-pico-bringup/src/main.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+
+use cortex_m::delay::Delay;
+use embedded_hal::i2c::I2c as _;
+use fugit::RateExtU32;
+use panic_halt as _;
+use platform_rp2040::{gpio::Rp2040OutputPin, i2c::Rp2040I2c};
+use rp_pico::entry;
+use rp_pico::hal;
+use rp_pico::hal::pac;
+use rp_pico::hal::Clock;
+
+use core_app::App;
+
+const I2C_FREQUENCY_HZ: u32 = 100_000;
+const HEARTBEAT_DELAY_MS: u32 = 250;
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = hal::Sio::new(pac.SIO);
+    let pins = rp_pico::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // UART0: GPIO0=TX, GPIO1=RX
+    let uart_pins = (
+        pins.gpio0.into_function::<hal::gpio::FunctionUart>(),
+        pins.gpio1.into_function::<hal::gpio::FunctionUart>(),
+    );
+    let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
+        .enable(
+            hal::uart::UartConfig::new(
+                115_200_u32.Hz(),
+                hal::uart::DataBits::Eight,
+                None,
+                hal::uart::StopBits::One,
+            ),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    // I2C0: GPIO4=SDA, GPIO5=SCL
+    let sda = pins.gpio4.into_function::<hal::gpio::FunctionI2C>();
+    let scl = pins.gpio5.into_function::<hal::gpio::FunctionI2C>();
+    let mut i2c = hal::I2C::new_controller(
+        pac.I2C0,
+        sda,
+        scl,
+        I2C_FREQUENCY_HZ.Hz(),
+        &mut pac.RESETS,
+        clocks.system_clock.freq(),
+    );
+
+    // LED: GPIO25 (onboard)
+    let led = pins.led.into_push_pull_output();
+
+    let mut delay = Delay::new(core.SYST, clocks.system_clock.freq().to_Hz());
+
+    uart.write_full_blocking(b"raspi-pico bring-up + hal-api demo\r\n");
+    uart.write_full_blocking(b"LED=GPIO25 SDA=GPIO4 SCL=GPIO5 UART0=GPIO0/1\r\n");
+    uart.write_full_blocking(
+        b"Use this firmware to confirm blink/UART/I2C before adding sensors.\r\n",
+    );
+
+    // I2C scan (0x08..=0x77)
+    uart.write_full_blocking(b"I2C scan:\r\n");
+    for addr in 0x08u8..=0x77 {
+        let mut buf = [0u8; 1];
+        if i2c.read(addr, &mut buf).is_ok() {
+            uart.write_full_blocking(b"  found device at 0x");
+            uart.write_full_blocking(&[hex_nibble(addr >> 4), hex_nibble(addr & 0x0F)]);
+            uart.write_full_blocking(b"\r\n");
+        }
+    }
+    uart.write_full_blocking(b"I2C scan done.\r\n");
+
+    // Wrap into hal-api adapters and run core-app
+    let rp2040_pin = Rp2040OutputPin::new(led);
+    let rp2040_i2c = Rp2040I2c::new(i2c);
+    let mut app = App::new(rp2040_pin, rp2040_i2c);
+
+    uart.write_full_blocking(b"Starting core-app via hal-api adapters...\r\n");
+
+    let mut heartbeat = 0u32;
+    loop {
+        heartbeat = heartbeat.wrapping_add(1);
+
+        if app.tick().is_err() {
+            uart.write_full_blocking(b"app.tick() error\r\n");
+        }
+
+        if heartbeat % 4 == 0 {
+            uart.write_full_blocking(b"heartbeat\r\n");
+        }
+
+        delay.delay_ms(HEARTBEAT_DELAY_MS);
+    }
+}
+
+fn hex_nibble(n: u8) -> u8 {
+    if n < 10 {
+        b'0' + n
+    } else {
+        b'a' + n - 10
+    }
+}


### PR DESCRIPTION
## 概要

- `crates/platform-rp2040` を新設（`platform-avr` と同構造の薄い adapter 層）
  - `Rp2040OutputPin<P>` — `hal-api::OutputPin` 実装
  - `Rp2040InputPin<P>` — `hal-api::InputPin` 実装
  - `Rp2040I2c<I>` — `hal-api::I2cBus` 実装
  - `no_std` 対応、`embedded-hal 1.0` ベース
- `firmware/raspi-pico-bringup` を新設
  - LED (GPIO25) / UART (GPIO0/1) / I2C scan (GPIO4/5) の動作確認
  - `core-app::App` を `platform-rp2040` adapter 経由で実行
  - BOOTSEL + `elf2uf2-rs` で書き込み

## テスト

- `platform-rp2040` 単体テスト: GPIO/I2C 正常系・error mapping
- `tests/app_bridge.rs`: `core_app_runs_with_rp2040_adapters` で sim-to-real contract を確認
- workspace 全体: 360 tests passed
- no_std: `thumbv6m-none-eabi` で `cargo check` 通過
- clippy: 警告なし

## テスト計画

- [ ] `cargo test -p platform-rp2040` が通ること
- [ ] `cargo test --workspace --all-targets` が通ること
- [ ] `cargo clippy --all --all-targets -- -D warnings` が通ること
- [ ] `cargo check -p platform-rp2040 --lib --target thumbv6m-none-eabi` が通ること
- [ ] CI の no_std / clippy ジョブが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)