### PR TITLE
fix(platform-rp2040,avr): address review findings from #123

### DIFF
--- a/crates/platform-avr/gpio.rs
+++ b/crates/platform-avr/gpio.rs
@@ -1,19 +1,17 @@
 //! AVR GPIO アダプタ
 
-use core::cell::{Ref, RefCell, RefMut};
+use core::cell::{Ref, RefCell};
 
 use embedded_hal::digital::{
-    Error as EmbeddedDigitalError, ErrorKind as EmbeddedDigitalErrorKind,
-    InputPin as EmbeddedInputPin, OutputPin as EmbeddedOutputPin,
+    Error as EmbeddedDigitalError, InputPin as EmbeddedInputPin, OutputPin as EmbeddedOutputPin,
 };
 use hal_api::error::GpioError;
 use hal_api::gpio::{InputPin, OutputPin};
 
 fn map_gpio_error(error: impl EmbeddedDigitalError) -> GpioError {
-    match error.kind() {
-        EmbeddedDigitalErrorKind::Other => GpioError::HardwareError,
-        _ => GpioError::HardwareError,
-    }
+    // ErrorKind is #[non_exhaustive]; all variants map to HardwareError.
+    let _ = error.kind();
+    GpioError::HardwareError
 }
 
 /// AVR 向けの出力ピンラッパー。
@@ -68,10 +66,6 @@ impl<P> AvrInputPin<P> {
 
     pub fn borrow_inner(&self) -> Ref<'_, P> {
         self.inner.borrow()
-    }
-
-    pub fn borrow_inner_mut(&self) -> RefMut<'_, P> {
-        self.inner.borrow_mut()
     }
 
     pub fn into_inner(self) -> P {

--- a/crates/platform-avr/i2c.rs
+++ b/crates/platform-avr/i2c.rs
@@ -18,6 +18,7 @@ fn map_i2c_error(error: impl EmbeddedI2cError) -> I2cError {
         | EmbeddedI2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown)
         | EmbeddedI2cErrorKind::Overrun
         | EmbeddedI2cErrorKind::Other => I2cError::BusError,
+        // #[non_exhaustive] forward-compat: future variants default to BusError.
         _ => I2cError::BusError,
     }
 }
@@ -199,5 +200,18 @@ mod tests {
         let mut buffer = [0u8; 2];
 
         assert_eq!(i2c.read(0x48, &mut buffer), Err(I2cError::BusError));
+    }
+
+    #[test]
+    fn avr_i2c_maps_write_read_errors() {
+        let mut i2c = AvrI2c::new(FailingI2c {
+            error: DummyI2cDriverError(EmbeddedI2cErrorKind::ArbitrationLoss),
+        });
+        let mut buffer = [0u8; 2];
+
+        assert_eq!(
+            i2c.write_read(0x48, &[0x01], &mut buffer),
+            Err(I2cError::BusError)
+        );
     }
 }

--- a/crates/platform-rp2040/gpio.rs
+++ b/crates/platform-rp2040/gpio.rs
@@ -1,19 +1,17 @@
 //! RP2040 GPIO アダプタ
 
-use core::cell::{Ref, RefCell, RefMut};
+use core::cell::{Ref, RefCell};
 
 use embedded_hal::digital::{
-    Error as EmbeddedDigitalError, ErrorKind as EmbeddedDigitalErrorKind,
-    InputPin as EmbeddedInputPin, OutputPin as EmbeddedOutputPin,
+    Error as EmbeddedDigitalError, InputPin as EmbeddedInputPin, OutputPin as EmbeddedOutputPin,
 };
 use hal_api::error::GpioError;
 use hal_api::gpio::{InputPin, OutputPin};
 
 fn map_gpio_error(error: impl EmbeddedDigitalError) -> GpioError {
-    match error.kind() {
-        EmbeddedDigitalErrorKind::Other => GpioError::HardwareError,
-        _ => GpioError::HardwareError,
-    }
+    // ErrorKind is #[non_exhaustive]; all variants map to HardwareError.
+    let _ = error.kind();
+    GpioError::HardwareError
 }
 
 /// RP2040 向けの出力ピンラッパー。
@@ -68,10 +66,6 @@ impl<P> Rp2040InputPin<P> {
 
     pub fn borrow_inner(&self) -> Ref<'_, P> {
         self.inner.borrow()
-    }
-
-    pub fn borrow_inner_mut(&self) -> RefMut<'_, P> {
-        self.inner.borrow_mut()
     }
 
     pub fn into_inner(self) -> P {

--- a/crates/platform-rp2040/i2c.rs
+++ b/crates/platform-rp2040/i2c.rs
@@ -18,6 +18,7 @@ fn map_i2c_error(error: impl EmbeddedI2cError) -> I2cError {
         | EmbeddedI2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown)
         | EmbeddedI2cErrorKind::Overrun
         | EmbeddedI2cErrorKind::Other => I2cError::BusError,
+        // #[non_exhaustive] forward-compat: future variants default to BusError.
         _ => I2cError::BusError,
     }
 }
@@ -199,5 +200,18 @@ mod tests {
         let mut buffer = [0u8; 2];
 
         assert_eq!(i2c.read(0x48, &mut buffer), Err(I2cError::BusError));
+    }
+
+    #[test]
+    fn rp2040_i2c_maps_write_read_errors() {
+        let mut i2c = Rp2040I2c::new(FailingI2c {
+            error: DummyI2cDriverError(EmbeddedI2cErrorKind::ArbitrationLoss),
+        });
+        let mut buffer = [0u8; 2];
+
+        assert_eq!(
+            i2c.write_read(0x48, &[0x01], &mut buffer),
+            Err(I2cError::BusError)
+        );
     }
 }

--- a/crates/platform-rp2040/tests/app_bridge.rs
+++ b/crates/platform-rp2040/tests/app_bridge.rs
@@ -1,6 +1,5 @@
 use core::convert::Infallible;
 
-#[cfg(test)]
 extern crate std;
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
## 概要

PR #123 の AI エージェントレビューで指摘された MEDIUM/LOW 項目を両 crate に適用。

## 変更内容

### platform-rp2040 / platform-avr 共通

| 指摘 | 対応 |
|---|---|
| `map_gpio_error` の dead `Other` arm | match を削除し `let _ = error.kind()` + コメントに置換 |
| `EmbeddedDigitalErrorKind` の未使用 import | 削除 |
| `borrow_inner_mut` が未使用 public API | メソッドごと削除（`is_high`/`is_low` は直接 `borrow_mut()` を使用） |
| `map_i2c_error` wildcard arm にコメントなし | `// #[non_exhaustive] forward-compat` コメント追加 |
| `write_read` error path テスト不足 | `ArbitrationLoss` → `BusError` のテスト追加 |

### platform-rp2040 のみ

| 指摘 | 対応 |
|---|---|
| integration test の `#[cfg(test)] extern crate std` が非対称 | `#[cfg(test)]` ガードを除去（integration test は常に std） |

## テスト

- 362 tests passed（360 → 362、`write_read` テスト ×2 追加）
- clippy: No issues
- fmt: OK

## テスト計画

- [ ] `cargo test --workspace --all-targets` が通ること
- [ ] `cargo clippy --all --all-targets -- -D warnings` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)