### PR TITLE
feat(platform-rp2040): add SharedI2cBus, BME280/LCD1602 re-exports and climate_bridge test

### DIFF
--- a/crates/platform-rp2040/Cargo.toml
+++ b/crates/platform-rp2040/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 [dependencies]
 embedded-hal = "1.0"
 hal-api = { version = "0.1.0", path = "../hal-api", default-features = false }
+reference-drivers = { version = "0.1.0", path = "../reference-drivers", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/crates/platform-rp2040/bme280.rs
+++ b/crates/platform-rp2040/bme280.rs
@@ -1,0 +1,3 @@
+//! RP2040 re-export of the board-agnostic BME280 driver.
+
+pub use reference_drivers::bme280::*;

--- a/crates/platform-rp2040/lcd1602.rs
+++ b/crates/platform-rp2040/lcd1602.rs
@@ -1,0 +1,3 @@
+//! RP2040 re-export of the board-agnostic LCD1602 driver.
+
+pub use reference_drivers::lcd1602::*;

--- a/crates/platform-rp2040/lib.rs
+++ b/crates/platform-rp2040/lib.rs
@@ -10,5 +10,8 @@
 //! これにより、Raspberry Pi Pico を追加するときも、
 //! `core-app` 側を変えずに platform 層だけで吸収できます。
 
+pub mod bme280;
 pub mod gpio;
 pub mod i2c;
+pub mod lcd1602;
+pub mod shared_i2c;

--- a/crates/platform-rp2040/shared_i2c.rs
+++ b/crates/platform-rp2040/shared_i2c.rs
@@ -1,0 +1,135 @@
+//! 共有 I2C バスアダプタ
+
+use core::cell::RefCell;
+
+use hal_api::error::I2cError;
+use hal_api::i2c::I2cBus;
+
+/// `RefCell` 上の I2C バスを複数デバイスへ共有するための薄いラッパーです。
+#[derive(Clone, Copy)]
+pub struct SharedI2cBus<'a, B> {
+    inner: &'a RefCell<B>,
+}
+
+impl<'a, B> SharedI2cBus<'a, B> {
+    pub const fn new(inner: &'a RefCell<B>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<B> I2cBus for SharedI2cBus<'_, B>
+where
+    B: I2cBus<Error = I2cError>,
+{
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.inner.borrow_mut().write(addr, bytes)
+    }
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.borrow_mut().read(addr, buffer)
+    }
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.borrow_mut().write_read(addr, bytes, buffer)
+    }
+}
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    use std::rc::Rc;
+    use std::vec;
+    use std::vec::Vec;
+
+    type WriteLog = Rc<RefCell<Vec<(u8, Vec<u8>)>>>;
+
+    #[derive(Default)]
+    struct DummyI2c {
+        writes: WriteLog,
+    }
+
+    impl I2cBus for DummyI2c {
+        type Error = I2cError;
+
+        fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+            self.writes.borrow_mut().push((addr, bytes.to_vec()));
+            Ok(())
+        }
+
+        fn read(&mut self, _addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+            buffer.fill(0xAA);
+            Ok(())
+        }
+
+        fn write_read(
+            &mut self,
+            addr: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            self.write(addr, bytes)?;
+            self.read(addr, buffer)
+        }
+    }
+
+    struct FailingI2c;
+
+    impl I2cBus for FailingI2c {
+        type Error = I2cError;
+
+        fn write(&mut self, _addr: u8, _bytes: &[u8]) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+
+        fn read(&mut self, _addr: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+
+        fn write_read(
+            &mut self,
+            _addr: u8,
+            _bytes: &[u8],
+            _buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            Err(I2cError::Timeout)
+        }
+    }
+
+    #[test]
+    fn shared_i2c_bus_allows_multiple_handles() {
+        let inner = RefCell::new(DummyI2c::default());
+        let writes = inner.borrow().writes.clone();
+        let mut bus_a = SharedI2cBus::new(&inner);
+        let mut bus_b = SharedI2cBus::new(&inner);
+        let mut buffer = [0u8; 2];
+
+        bus_a.write(0x27, &[0x01]).unwrap();
+        bus_b.write_read(0x77, &[0xF7], &mut buffer).unwrap();
+
+        assert_eq!(
+            writes.borrow().as_slice(),
+            &[(0x27, vec![0x01]), (0x77, vec![0xF7])]
+        );
+        assert_eq!(buffer, [0xAA, 0xAA]);
+    }
+
+    #[test]
+    fn shared_i2c_bus_propagates_inner_bus_errors() {
+        let inner = RefCell::new(FailingI2c);
+        let mut bus = SharedI2cBus::new(&inner);
+        let mut buffer = [0u8; 2];
+
+        assert_eq!(bus.write(0x27, &[0x01]), Err(I2cError::Timeout));
+        assert_eq!(bus.read(0x27, &mut buffer), Err(I2cError::Timeout));
+        assert_eq!(
+            bus.write_read(0x77, &[0xF7], &mut buffer),
+            Err(I2cError::Timeout)
+        );
+    }
+}

--- a/crates/platform-rp2040/tests/climate_bridge.rs
+++ b/crates/platform-rp2040/tests/climate_bridge.rs
@@ -1,0 +1,122 @@
+use core::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+use core_app::climate_display::{ClimateDisplayApp, ClimateDisplayConfig};
+use embedded_hal::delay::DelayNs;
+use hal_api::error::I2cError;
+use hal_api::i2c::I2cBus;
+use platform_rp2040::bme280::Bme280Sensor;
+use platform_rp2040::lcd1602::{Lcd1602Display, LCD1602_ADDRESS_PRIMARY};
+use platform_rp2040::shared_i2c::SharedI2cBus;
+
+const REG_CHIP_ID: u8 = 0xD0;
+const REG_CALIB_1_START: u8 = 0x88;
+const REG_CALIB_2_START: u8 = 0xE1;
+const REG_STATUS: u8 = 0xF3;
+const REG_PRESS_MSB: u8 = 0xF7;
+
+type BusLog = Rc<RefCell<Vec<(u8, Vec<u8>)>>>;
+
+#[derive(Clone, Default)]
+struct MultiplexedI2c {
+    writes: BusLog,
+    responses: BusLog,
+}
+
+impl MultiplexedI2c {
+    fn with_bme280_defaults() -> Self {
+        let bus = Self::default();
+        bus.set_response(REG_CHIP_ID, &[0x60]);
+        bus.set_response(REG_STATUS, &[0x00]);
+        bus.set_response(
+            REG_CALIB_1_START,
+            &[
+                0x70, 0x6B, 0x43, 0x67, 0x18, 0xFC, 0x7D, 0x8E, 0x43, 0xD6, 0xD0, 0x0B, 0x27, 0x0B,
+                0x8C, 0x00, 0xF9, 0xFF, 0x8C, 0x3C, 0xF8, 0xC6, 0x70, 0x17, 0x00, 0x4B,
+            ],
+        );
+        bus.set_response(
+            REG_CALIB_2_START,
+            &[0x6A, 0x01, 0x00, 0x14, 0x25, 0x03, 0x1E],
+        );
+        bus.set_response(
+            REG_PRESS_MSB,
+            &[0x65, 0x5A, 0xC0, 0x7E, 0xED, 0x00, 0x89, 0x98],
+        );
+        bus
+    }
+
+    fn set_response(&self, register: u8, bytes: &[u8]) {
+        let mut responses = self.responses.borrow_mut();
+        responses.retain(|(candidate, _)| *candidate != register);
+        responses.push((register, bytes.to_vec()));
+    }
+}
+
+impl I2cBus for MultiplexedI2c {
+    type Error = I2cError;
+
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.writes.borrow_mut().push((addr, bytes.to_vec()));
+        Ok(())
+    }
+
+    fn read(&mut self, _addr: u8, _buffer: &mut [u8]) -> Result<(), Self::Error> {
+        Err(I2cError::BusError)
+    }
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.writes.borrow_mut().push((addr, bytes.to_vec()));
+        let register = *bytes.first().ok_or(I2cError::BusError)?;
+        let response = self
+            .responses
+            .borrow()
+            .iter()
+            .find(|(candidate, _)| *candidate == register)
+            .map(|(_, data)| data.clone())
+            .ok_or(I2cError::InvalidAddress)?;
+        if response.len() != buffer.len() {
+            return Err(I2cError::BusError);
+        }
+        buffer.copy_from_slice(&response);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NoopDelay;
+
+impl DelayNs for NoopDelay {
+    fn delay_ns(&mut self, _ns: u32) {}
+    fn delay_us(&mut self, _us: u32) {}
+    fn delay_ms(&mut self, _ms: u32) {}
+}
+
+#[test]
+fn climate_display_app_uses_shared_i2c_for_sensor_and_display() {
+    let inner = RefCell::new(MultiplexedI2c::with_bme280_defaults());
+    let writes = inner.borrow().writes.clone();
+
+    let sensor = Bme280Sensor::new(SharedI2cBus::new(&inner));
+    let display = Lcd1602Display::new(SharedI2cBus::new(&inner), NoopDelay);
+    let mut app = ClimateDisplayApp::new_with_config(
+        sensor,
+        display,
+        ClimateDisplayConfig {
+            refresh_period_ticks: 1,
+            refresh_on_first_tick: true,
+        },
+    );
+
+    app.tick().unwrap();
+
+    assert!(writes
+        .borrow()
+        .iter()
+        .any(|(addr, bytes)| *addr == 0x77 && bytes.as_slice() == [0xF2, 0x01]));
+    assert!(writes
+        .borrow()
+        .iter()
+        .any(|(addr, _)| *addr == LCD1602_ADDRESS_PRIMARY));
+}


### PR DESCRIPTION
## 概要

`platform-rp2040` に `platform-esp32` と同等の sensor/display 統合層を追加し、
`ClimateDisplayApp` が Pico 向け adapter 経由で動作することを統合テストで証明します。

## 変更内容

| ファイル | 内容 |
|---|---|
| `shared_i2c.rs` | `SharedI2cBus<'a, B>` — `RefCell` 上の I2C バスを複数デバイスへ共有 |
| `bme280.rs` | `reference_drivers::bme280::*` の re-export |
| `lcd1602.rs` | `reference_drivers::lcd1602::*` の re-export |
| `lib.rs` | 上記 3 モジュールを追加 |
| `Cargo.toml` | `reference-drivers` 依存を追加 |
| `tests/climate_bridge.rs` | `ClimateDisplayApp` が `SharedI2cBus` 経由で BME280 + LCD1602 を駆動することを確認 |

## テスト

- 365 tests passed（362 → +3）
  - `climate_bridge::climate_display_app_uses_shared_i2c_for_sensor_and_display`
  - `shared_i2c::tests::shared_i2c_bus_allows_multiple_handles`
  - `shared_i2c::tests::shared_i2c_bus_propagates_inner_bus_errors`
- clippy: No issues
- fmt: OK
- no_std (`thumbv6m-none-eabi`): cargo check PASS

## テスト計画

- [ ] `cargo test -p platform-rp2040 --test climate_bridge` が通ること
- [ ] `cargo test --workspace --all-targets` が通ること
- [ ] `cargo clippy --all --all-targets -- -D warnings` が通ること
- [ ] `cargo check -p platform-rp2040 --lib --target thumbv6m-none-eabi` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)