### PR TITLE
feat(firmware): add raspi-pico-climate-display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ platform-pc-sim -> core-app -> platform-esp32 -> original ESP32 + BME280 + LCD16
 - ✅ `ClimateDisplayApp` の PC simulator と original ESP32 climate display reference path
 - ✅ BME280 / LCD1602 / SharedI2cBus の基本・異常系テスト
 - ✅ `platform-rp2040` の adapter 層と Raspberry Pi Pico bring-up firmware
+- ✅ `ClimateDisplayApp` の Raspberry Pi Pico 実機経路 (`raspi-pico-climate-display`)
 - 🚧 Phase 4: no_std 対応と original ESP32 / Raspberry Pi Pico 実機確認手順の維持・拡張
 
 ## スコープ方針
@@ -101,14 +102,18 @@ mcu-hal-sim-rs/
 │   │
 │   └── platform-rp2040/     # Raspberry Pi Pico (RP2040) adapter layer
 │       ├── gpio.rs          # Rp2040OutputPin / Rp2040InputPin
-│       └── i2c.rs           # Rp2040I2c
+│       ├── i2c.rs           # Rp2040I2c
+│       ├── shared_i2c.rs    # SharedI2cBus
+│       ├── bme280.rs        # reference-drivers re-export
+│       └── lcd1602.rs       # reference-drivers re-export
 │
 ├── firmware/
 │   ├── original-esp32-bringup/
 │   ├── original-esp32-climate-display/
 │   ├── m5stickc-bringup/
 │   ├── arduino-nano-bringup/
-│   └── raspi-pico-bringup/
+│   ├── raspi-pico-bringup/
+│   └── raspi-pico-climate-display/
 ├── docs/
 ├── scripts/
 └── .github/workflows/ci.yml
@@ -142,10 +147,11 @@ cargo clippy --all --all-targets -- -D warnings
 # ローカル CI 相当
 ./scripts/ci-local.sh
 
-# no_std / ESP32 関連チェック
+# no_std チェック
 cargo check -p hal-api --lib --target thumbv6m-none-eabi
 cargo check -p core-app --lib --target thumbv6m-none-eabi
 cargo check -p platform-esp32 --lib --target thumbv6m-none-eabi
+cargo check -p platform-rp2040 --lib --target thumbv6m-none-eabi
 cargo check-esp32
 
 # reference path 周辺の絞り込み
@@ -154,6 +160,8 @@ cargo test -p reference-drivers bme280
 cargo test -p reference-drivers lcd1602
 cargo test -p platform-esp32 shared_i2c
 cargo test -p platform-esp32 --test climate_bridge
+cargo test -p platform-rp2040 shared_i2c
+cargo test -p platform-rp2040 --test climate_bridge
 ```
 
 ## Simulator / firmware の使い分け
@@ -178,11 +186,16 @@ cargo run --release
 cd firmware/original-esp32-climate-display
 cargo check --release
 cargo run --release
+
+# Raspberry Pi Pico climate display
+cd firmware/raspi-pico-climate-display
+cargo check --release
+cargo run --release
 ```
 
-## original ESP32 reference path
+## ClimateDisplayApp reference path
 
-`core_app::climate_display::ClimateDisplayApp` は次の 2 経路で共通利用します。
+`core_app::climate_display::ClimateDisplayApp` は次の 3 経路で共通利用します。
 
 - PC simulator
   - `platform-pc-sim::climate_sim::{SequenceEnvSensor, TerminalDisplay16x2}`
@@ -190,11 +203,22 @@ cargo run --release
 - original ESP32
   - `platform-esp32::{Bme280Sensor, Lcd1602Display, SharedI2cBus}`
   - firmware: `firmware/original-esp32-climate-display`
+- Raspberry Pi Pico
+  - `platform-rp2040::{Bme280Sensor, Lcd1602Display, SharedI2cBus}`
+  - firmware: `firmware/raspi-pico-climate-display`
 
 既定の実機想定:
 
+**original ESP32:**
 - board: original ESP32 / ESP32-WROOM-32 系
 - I2C: `GPIO21` = SDA, `GPIO22` = SCL
+- BME280: `0x77` 優先、必要に応じて `0x76`
+- LCD1602 backpack: `0x27`
+
+**Raspberry Pi Pico:**
+- board: Raspberry Pi Pico (RP2040)
+- I2C: `GPIO4` = SDA, `GPIO5` = SCL
+- UART: `GPIO0` = TX, `GPIO1` = RX (115200)
 - BME280: `0x77` 優先、必要に応じて `0x76`
 - LCD1602 backpack: `0x27`
 
@@ -203,7 +227,7 @@ cargo run --release
 - `core-app` に board 固有分岐を入れない
 - board / sensor / display 差分は config struct に閉じ込める
 - `reference-drivers` は board 非依存を維持する
-- `platform-esp32` は adapter / re-export / type alias を中心に薄く保つ
+- `platform-esp32` / `platform-rp2040` は adapter / re-export / type alias を中心に薄く保つ
 - host simulator で先に contract を固定してから実機経路に接続する
 - 実機手順や wiring 前提を変えたら README / PLAN / firmware README を同期する
 

--- a/firmware/raspi-pico-climate-display/.cargo/config.toml
+++ b/firmware/raspi-pico-climate-display/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = "elf2uf2-rs -d"
+rustflags = [
+    "-C", "link-arg=--nmagic",
+    "-C", "link-arg=-Tlink.x",
+]

--- a/firmware/raspi-pico-climate-display/Cargo.toml
+++ b/firmware/raspi-pico-climate-display/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "raspi-pico-climate-display"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[[bin]]
+name = "raspi-pico-climate-display"
+path = "src/main.rs"
+test = false
+bench = false
+
+[dependencies]
+rp-pico = "0.9"
+embedded-hal = "1.0"
+panic-halt = "1.0"
+fugit = "0.3"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+platform-rp2040 = { path = "../../crates/platform-rp2040" }
+core-app = { path = "../../crates/core-app", default-features = false }
+hal-api = { path = "../../crates/hal-api", default-features = false }
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = "s"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+debug = true
+lto = true
+opt-level = "s"

--- a/firmware/raspi-pico-climate-display/README.md
+++ b/firmware/raspi-pico-climate-display/README.md
@@ -1,0 +1,83 @@
+# raspi-pico-climate-display
+
+Raspberry Pi Pico (RP2040) + `BME280` + `LCD1602` I2C backpack 向けの climate display firmware です。
+
+この crate は `core-app::climate_display::ClimateDisplayApp` をそのまま使い、
+センサ読み取りと 16x2 表示だけを `platform-rp2040` のデバイスドライバへ差し替えます。
+目的は、PC simulator で確認した表示ロジックを Pico 実機へそのまま持ち込める経路を固定することです。
+
+## いつ使うか
+
+- 表示文言や 16x2 UI を host 上で確認したい:
+  - `cargo run -p platform-pc-sim --bin climate-display-sim`
+- USB / UART / 汎用 I2C の疎通だけを先に切り分けたい:
+  - `firmware/raspi-pico-bringup`
+- `BME280 + LCD1602` の本命経路を Pico で確認したい:
+  - この `raspi-pico-climate-display`
+
+## 対応前提
+
+- ボード: Raspberry Pi Pico (RP2040)
+- センサ: `BME280`
+- ディスプレイ: `LCD1602` + `PCF8574` 系 I2C backpack
+- I2C:
+  - `GPIO4` -> `SDA`
+  - `GPIO5` -> `SCL`
+- UART (シリアルログ):
+  - `GPIO0` -> `TX`
+  - `GPIO1` -> `RX`
+  - ボーレート: 115200
+- 既定アドレス:
+  - `BME280`: `0x77` を優先しつつ、firmware 起動時に `0x76` も probe
+  - `LCD1602 backpack`: `0x27`
+
+## 実行
+
+```bash
+# firmware ディレクトリ内で実行
+cd firmware/raspi-pico-climate-display
+
+# uf2 書き込み (BOOTSEL ボタンを押しながら USB 接続してから)
+cargo run --release
+```
+
+`elf2uf2-rs` がインストールされていない場合:
+
+```bash
+cargo install elf2uf2-rs
+```
+
+この firmware は起動後に次を行います。
+
+- BME280 の chip-id probe (`0x77` → `0x76` の順)
+- BME280 の calibration 読み出し
+- LCD1602 の 4-bit 初期化
+- `ClimateDisplayApp` の tick ループ (100 ms / tick)
+- 温度 / 湿度の 16x2 表示更新
+
+シリアルログでは次のような refresh telemetry が出ます。
+
+```text
+Raspberry Pi Pico climate display started
+I2C: SDA=GPIO4 SCL=GPIO5 BME280=0x77 LCD1602=0x27
+refresh: every 10 ticks (100 ms loop)
+BME280 probe: detected at 0x77 (chip-id=0x60)
+climate refresh tick=1 temp_cc=2481 hum_cp=4315 line1="Temp    24.8C   " line2="Hum     43.2%   "
+climate refresh tick=10 temp_cc=2483 hum_cp=4312 line1="Temp    24.8C   " line2="Hum     43.1%   "
+```
+
+この出力は `original-esp32-climate-display` や simulator 側の expected frame と比較しやすいようにしています。
+
+## 確認範囲
+
+- host 側の `cargo test --workspace --all-targets`
+- host 側の `cargo clippy --workspace --all-targets -- -D warnings`
+- この crate の `cargo check --release` または toolchain / linker / `elf2uf2-rs` が揃った環境での `cargo build --release`
+- Pico + `BME280` + `LCD1602` で温湿度表示を実機確認
+- 実機シリアルで `climate refresh tick=...` の継続出力を確認
+
+## 既知の前提
+
+- LCD backpack のビット割り当ては、一般的な `0x27` ボードの既定値を前提にしています
+- もし文字化けや初期化失敗が出る場合は、`platform-rp2040::lcd1602::Lcd1602Config` の `mapping` を実機に合わせて変更してください
+- `Delay` は SysTick ベースで LCD 初期化と tick ループに共有しています。SysTick を他の用途に使う場合は `SharedDelay` パターンを調整してください

--- a/firmware/raspi-pico-climate-display/rust-toolchain.toml
+++ b/firmware/raspi-pico-climate-display/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["rust-src"]
+targets = ["thumbv6m-none-eabi"]
+profile = "minimal"

--- a/firmware/raspi-pico-climate-display/src/main.rs
+++ b/firmware/raspi-pico-climate-display/src/main.rs
@@ -1,0 +1,248 @@
+#![no_std]
+#![no_main]
+
+use core::cell::RefCell;
+use core::fmt::Write as _;
+
+use cortex_m::delay::Delay;
+use embedded_hal::delay::DelayNs;
+use fugit::RateExtU32;
+use panic_halt as _;
+use platform_rp2040::bme280::{
+    BME280_ADDRESS_PRIMARY, BME280_ADDRESS_SECONDARY, Bme280Config, Bme280Sensor,
+};
+use platform_rp2040::i2c::Rp2040I2c;
+use platform_rp2040::lcd1602::{LCD1602_ADDRESS_PRIMARY, Lcd1602Config, Lcd1602Display};
+use platform_rp2040::shared_i2c::SharedI2cBus;
+use rp_pico::entry;
+use rp_pico::hal;
+use rp_pico::hal::pac;
+use rp_pico::hal::Clock;
+
+use core_app::climate_display::{ClimateDisplayApp, ClimateDisplayConfig};
+use hal_api::display::TextFrame16x2;
+
+const I2C_SDA_GPIO: u8 = 4;
+const I2C_SCL_GPIO: u8 = 5;
+const REFRESH_PERIOD_TICKS: u32 = 10;
+const LOOP_DELAY_MS: u32 = 100;
+const BME280_CHIP_ID_REGISTER: u8 = 0xD0;
+const BME280_CHIP_ID_VALUE: u8 = 0x60;
+
+/// `cortex_m::delay::Delay` を `embedded_hal::delay::DelayNs` に橋渡しするラッパー。
+struct PicoDelay(Delay);
+
+impl DelayNs for PicoDelay {
+    fn delay_ns(&mut self, ns: u32) {
+        self.0.delay_us(ns.div_ceil(1000));
+    }
+
+    fn delay_us(&mut self, us: u32) {
+        self.0.delay_us(us);
+    }
+
+    fn delay_ms(&mut self, ms: u32) {
+        self.0.delay_ms(ms);
+    }
+}
+
+/// `RefCell<PicoDelay>` を複数箇所から共有するための薄いラッパー。
+/// `SharedI2cBus` と同じパターン。
+struct SharedDelay<'a>(&'a RefCell<PicoDelay>);
+
+impl DelayNs for SharedDelay<'_> {
+    fn delay_ns(&mut self, ns: u32) {
+        self.0.borrow_mut().delay_ns(ns);
+    }
+
+    fn delay_us(&mut self, us: u32) {
+        self.0.borrow_mut().delay_us(us);
+    }
+
+    fn delay_ms(&mut self, ms: u32) {
+        self.0.borrow_mut().delay_ms(ms);
+    }
+}
+
+fn every_nth(value: u32, period: u32) -> bool {
+    period != 0 && value % period == 0
+}
+
+fn should_log_refresh(tick: u32, config: ClimateDisplayConfig) -> bool {
+    (config.refresh_on_first_tick && tick == 1)
+        || every_nth(tick, config.refresh_period_ticks.max(1))
+}
+
+fn frame_line(frame: &TextFrame16x2, row: usize) -> &str {
+    core::str::from_utf8(frame.line(row)).unwrap_or("????????????????")
+}
+
+fn detect_bme280_address<B, W>(bus: &mut B, uart: &mut W) -> u8
+where
+    B: hal_api::i2c::I2cBus<Error = hal_api::error::I2cError>,
+    W: core::fmt::Write,
+{
+    for address in [BME280_ADDRESS_PRIMARY, BME280_ADDRESS_SECONDARY] {
+        let mut chip_id = [0u8; 1];
+        match bus.write_read(address, &[BME280_CHIP_ID_REGISTER], &mut chip_id) {
+            Ok(()) if chip_id[0] == BME280_CHIP_ID_VALUE => {
+                let _ = write!(
+                    uart,
+                    "BME280 probe: detected at 0x{:02x} (chip-id=0x{:02x})\r\n",
+                    address, chip_id[0]
+                );
+                return address;
+            }
+            Ok(()) => {
+                let _ = write!(
+                    uart,
+                    "BME280 probe: 0x{:02x} unexpected chip-id=0x{:02x}\r\n",
+                    address, chip_id[0]
+                );
+            }
+            Err(_) => {
+                let _ = write!(uart, "BME280 probe: 0x{:02x} no response\r\n", address);
+            }
+        }
+    }
+    let _ = write!(
+        uart,
+        "BME280 probe: fallback to 0x{:02x}\r\n",
+        BME280_ADDRESS_PRIMARY
+    );
+    BME280_ADDRESS_PRIMARY
+}
+
+#[entry]
+fn main() -> ! {
+    let mut pac = pac::Peripherals::take().unwrap();
+    let core = pac::CorePeripherals::take().unwrap();
+
+    let mut watchdog = hal::Watchdog::new(pac.WATCHDOG);
+    let clocks = hal::clocks::init_clocks_and_plls(
+        rp_pico::XOSC_CRYSTAL_FREQ,
+        pac.XOSC,
+        pac.CLOCKS,
+        pac.PLL_SYS,
+        pac.PLL_USB,
+        &mut pac.RESETS,
+        &mut watchdog,
+    )
+    .ok()
+    .unwrap();
+
+    let sio = hal::Sio::new(pac.SIO);
+    let pins = rp_pico::Pins::new(
+        pac.IO_BANK0,
+        pac.PADS_BANK0,
+        sio.gpio_bank0,
+        &mut pac.RESETS,
+    );
+
+    // UART0: GPIO0=TX, GPIO1=RX
+    let uart_pins = (
+        pins.gpio0.into_function::<hal::gpio::FunctionUart>(),
+        pins.gpio1.into_function::<hal::gpio::FunctionUart>(),
+    );
+    let mut uart = hal::uart::UartPeripheral::new(pac.UART0, uart_pins, &mut pac.RESETS)
+        .enable(
+            hal::uart::UartConfig::new(
+                115_200_u32.Hz(),
+                hal::uart::DataBits::Eight,
+                None,
+                hal::uart::StopBits::One,
+            ),
+            clocks.peripheral_clock.freq(),
+        )
+        .unwrap();
+
+    // I2C0: GPIO4=SDA, GPIO5=SCL
+    let sda = pins.gpio4.into_function::<hal::gpio::FunctionI2C>();
+    let scl = pins.gpio5.into_function::<hal::gpio::FunctionI2C>();
+    let i2c = hal::I2C::new_controller(
+        pac.I2C0,
+        sda,
+        scl,
+        100_000u32.Hz(),
+        &mut pac.RESETS,
+        clocks.system_clock.freq(),
+    );
+    let mut rp2040_i2c = Rp2040I2c::new(i2c);
+    let bme280_address = detect_bme280_address(&mut rp2040_i2c, &mut uart);
+    let shared_bus = RefCell::new(rp2040_i2c);
+
+    let shared_delay = RefCell::new(PicoDelay(Delay::new(
+        core.SYST,
+        clocks.system_clock.freq().to_Hz(),
+    )));
+
+    let app_config = ClimateDisplayConfig {
+        refresh_period_ticks: REFRESH_PERIOD_TICKS,
+        refresh_on_first_tick: true,
+    };
+
+    let sensor = Bme280Sensor::new_with_config(
+        SharedI2cBus::new(&shared_bus),
+        Bme280Config {
+            address: bme280_address,
+            ..Bme280Config::default()
+        },
+    );
+    let display = Lcd1602Display::new_with_config(
+        SharedI2cBus::new(&shared_bus),
+        SharedDelay(&shared_delay),
+        Lcd1602Config {
+            address: LCD1602_ADDRESS_PRIMARY,
+            ..Lcd1602Config::default()
+        },
+    );
+    let mut app = ClimateDisplayApp::new_with_config(sensor, display, app_config);
+
+    let _ = write!(uart, "Raspberry Pi Pico climate display started\r\n");
+    let _ = write!(
+        uart,
+        "I2C: SDA=GPIO{} SCL=GPIO{} BME280=0x{:02x} LCD1602=0x{:02x}\r\n",
+        I2C_SDA_GPIO, I2C_SCL_GPIO, bme280_address, LCD1602_ADDRESS_PRIMARY
+    );
+    let _ = write!(
+        uart,
+        "refresh: every {} ticks ({} ms loop)\r\n",
+        REFRESH_PERIOD_TICKS, LOOP_DELAY_MS
+    );
+
+    let mut tick = 0u32;
+    loop {
+        match app.tick() {
+            Ok(()) => {
+                tick += 1;
+                if should_log_refresh(tick, app_config) {
+                    match (app.last_reading(), app.last_frame()) {
+                        (Some(reading), Some(frame)) => {
+                            let _ = write!(
+                                uart,
+                                "climate refresh tick={} temp_cc={} hum_cp={} line1=\"{}\" line2=\"{}\"\r\n",
+                                tick,
+                                reading.temperature_centi_celsius,
+                                reading.humidity_centi_percent,
+                                frame_line(&frame, 0),
+                                frame_line(&frame, 1)
+                            );
+                        }
+                        _ => {
+                            let _ = write!(
+                                uart,
+                                "climate refresh tick={} frame unavailable\r\n",
+                                tick
+                            );
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                let _ = write!(uart, "climate tick failed: {:?}\r\n", error);
+            }
+        }
+
+        shared_delay.borrow_mut().delay_ms(LOOP_DELAY_MS);
+    }
+}

--- a/firmware/raspi-pico-climate-display/src/main.rs
+++ b/firmware/raspi-pico-climate-display/src/main.rs
@@ -88,7 +88,7 @@ where
             Ok(()) if chip_id[0] == BME280_CHIP_ID_VALUE => {
                 let _ = write!(
                     uart,
-                    "BME280 probe: detected at 0x{:02x} (chip-id=0x{:02x})\r\n",
+                    "BME280 probe: detected sensor at 0x{:02x} (chip-id=0x{:02x})\r\n",
                     address, chip_id[0]
                 );
                 return address;
@@ -96,18 +96,22 @@ where
             Ok(()) => {
                 let _ = write!(
                     uart,
-                    "BME280 probe: 0x{:02x} unexpected chip-id=0x{:02x}\r\n",
+                    "BME280 probe: address 0x{:02x} responded with unexpected chip-id=0x{:02x}\r\n",
                     address, chip_id[0]
                 );
             }
-            Err(_) => {
-                let _ = write!(uart, "BME280 probe: 0x{:02x} no response\r\n", address);
+            Err(error) => {
+                let _ = write!(
+                    uart,
+                    "BME280 probe: address 0x{:02x} failed: {:?}\r\n",
+                    address, error
+                );
             }
         }
     }
     let _ = write!(
         uart,
-        "BME280 probe: fallback to 0x{:02x}\r\n",
+        "BME280 probe: falling back to default address 0x{:02x}\r\n",
         BME280_ADDRESS_PRIMARY
     );
     BME280_ADDRESS_PRIMARY


### PR DESCRIPTION
## 概要

- `firmware/raspi-pico-climate-display` を新規追加
- `ClimateDisplayApp` を `platform-rp2040` 経由で Raspberry Pi Pico 実機に接続する firmware
- `original-esp32-climate-display` と同じ sim-to-real 経路を RP2040 で実現

## 変更内容

| ファイル | 内容 |
|---|---|
| `firmware/raspi-pico-climate-display/Cargo.toml` | 独立 workspace、`platform-rp2040` / `core-app` / `hal-api` を path dep で参照 |
| `firmware/raspi-pico-climate-display/.cargo/config.toml` | `thumbv6m-none-eabi` ターゲット、`elf2uf2-rs -d` runner |
| `firmware/raspi-pico-climate-display/rust-toolchain.toml` | stable channel、thumbv6m-none-eabi target |
| `firmware/raspi-pico-climate-display/src/main.rs` | 起動・I2C 初期化・BME280 probe・tick ループ |
| `firmware/raspi-pico-climate-display/README.md` | ピン配線・実行手順・シリアルログ例 |

## 設計上のポイント

### `SharedDelay` パターン

`cortex_m::delay::Delay` は SysTick シングルトンなので複製不可。
`PicoDelay` ラッパーを `RefCell` に包み、`SharedDelay<'_>` 経由で
LCD1602 初期化とメインループ両方から借用する（`SharedI2cBus` と同一パターン）。

### シリアルログ形式

`original-esp32-climate-display` と同じフォーマットで出力：

```text
climate refresh tick=1 temp_cc=2481 hum_cp=4315 line1="Temp    24.8C   " line2="Hum     43.2%   "
```

## 確認済み

- `cargo check --release`（`thumbv6m-none-eabi`）: pass
- `cargo test --workspace --all-targets`: 365 tests pass
- `cargo clippy --all --all-targets -- -D warnings`: クリーン

## テスト計画

- [ ] `cargo check --release` が通ることを CI で確認
- [ ] Pico 実機 + BME280 + LCD1602 で温湿度表示を確認（実機確認は任意）
- [ ] シリアルログで `climate refresh tick=...` が継続出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)